### PR TITLE
Hardcode Direct2D render target DPI to 96 (100%)

### DIFF
--- a/platform/windows/windows_display.cpp
+++ b/platform/windows/windows_display.cpp
@@ -243,7 +243,7 @@ BOOL PX_CreateWindow( int surfaceWidth,int surfaceHeight,int windowWidth,int win
 	size.height=rc.bottom - rc.top;
 
 	hr=D2D_pDirect2dFactory->CreateHwndRenderTarget(
-		D2D1::RenderTargetProperties(),
+		D2D1::RenderTargetProperties(D2D1_RENDER_TARGET_TYPE_DEFAULT, D2D1::PixelFormat(), 96.0F, 96.0F, D2D1_RENDER_TARGET_USAGE_NONE, D2D1_FEATURE_LEVEL_DEFAULT),
 		D2D1::HwndRenderTargetProperties(Win_Hwnd, size),
 		&D2D_pRenderTarget
 		);


### PR DESCRIPTION
According to [Microsoft Docs](https://docs.microsoft.com/zh-cn/windows/win32/api/d2d1/nf-d2d1-id2d1rendertarget-getdpi):

> For ID2D1HwndRenderTarget, the DPI defaults to the most recently factory-read system DPI. The default value for all other render targets is 96 DPI.

By setting ID2D1HwndRenderTarget DPI to 96 at creation, along with DPI awareness turned on in manifest file, the render target should fit to window size correctly.