### PR TITLE
docs: fix simple typo, drammatically -> dramatically

### DIFF
--- a/core/PX_rbtree.h
+++ b/core/PX_rbtree.h
@@ -20,7 +20,7 @@
   linux/include/linux/rbtree.h
 
   To use rbtrees you'll have to implement your own insert and search cores.
-  This will avoid us to use callbacks and to drop drammatically performances.
+  This will avoid us to use callbacks and to drop dramatically performances.
   I know it's not the cleaner way,  but in C (not in C++) to get
   performances and genericity...
 


### PR DESCRIPTION
There is a small typo in core/PX_rbtree.h.

Should read `dramatically` rather than `drammatically`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md