### PR TITLE
[PX_Animation]修复可能在某些处理器上出现的未对齐问题

### DIFF
--- a/kernel/PX_Animation.c
+++ b/kernel/PX_Animation.c
@@ -4,7 +4,7 @@ px_bool PX_AnimationLibraryCreateFromMemory(px_memorypool *mp,PX_Animationlibrar
 {
 	PX_2DX_Header _header;
 	PX_TRaw_Header _trawheader;
-	px_int i;
+	px_int i,j;
 	px_byte *pbuffer;
 	px_uint reservedSize=size;
 	px_texture texture;
@@ -34,7 +34,10 @@ px_bool PX_AnimationLibraryCreateFromMemory(px_memorypool *mp,PX_Animationlibrar
 	PX_MemoryInitialize(mp,&panimation->code);
 	for (i=0;i<(px_int)_header.framecount;i++)
 	{
-		_trawheader=*(PX_TRaw_Header *)pbuffer;
+		for(j=0;j<sizeof(PX_TRaw_Header);j++)
+		{
+			*(((px_byte *)&_trawheader)+j)=*(pbuffer+j);
+		}
 
 		if (!PX_TextureCreateFromMemory(mp,pbuffer,reservedSize,&texture))
 		{


### PR DESCRIPTION
访问pbuffer可能出现未对齐的问题，在某些处理器上会报unaligned错误