### PR TITLE
Add `PX_ObjectSetParent` and typo fix

### DIFF
--- a/kernel/PX_Object.c
+++ b/kernel/PX_Object.c
@@ -794,7 +794,7 @@ px_float PX_ObjectGetWidth(PX_Object *Object)
 	return Object->Width;
 }
 
-px_void PX_ObjectAddClild(PX_Object *Parent,PX_Object *child)
+px_void PX_ObjectAddChild(PX_Object *Parent,PX_Object *child)
 {
 	PX_Object *pLinker;
 	child->pParent=Parent;
@@ -857,7 +857,7 @@ px_void PX_ObjectInitialize(px_memorypool *mp,PX_Object *pObject,PX_Object *Pare
 		}
 		else
 		{
-			PX_ObjectAddClild(Parent,pObject);
+			PX_ObjectAddChild(Parent,pObject);
 		}
 		
 	}

--- a/kernel/PX_Object.c
+++ b/kernel/PX_Object.c
@@ -486,6 +486,56 @@ static px_void PX_Object_DeleteLinkerObject( PX_Object **ppObject )
 	(*ppObject)=PX_NULL;
 }
 
+px_void PX_ObjectSetParent(PX_Object *pObject, PX_Object *pParent)
+{
+	if (pObject==PX_NULL) return;
+	if (pObject->pParent==pParent) return;
+	if (pObject->OnFocus) PX_ObjectClearFocus(pObject);
+
+	// detach from parent
+	if (pObject->pParent!=PX_NULL)
+	{
+		if (pObject->pParent->pChilds==pObject)
+		{
+		   pObject->pParent->pChilds=pObject->pNextBrother;
+		   if(pObject->pNextBrother)
+		   {
+		   pObject->pNextBrother->pParent=pObject->pParent;
+		   pObject->pNextBrother->pPreBrother=PX_NULL;
+		   }
+		}
+		else
+		{
+			if (pObject->pPreBrother!=PX_NULL)
+			{
+				pObject->pPreBrother->pNextBrother=pObject->pNextBrother;
+				if(pObject->pNextBrother)
+				pObject->pNextBrother->pPreBrother=pObject->pPreBrother;
+			}
+			else
+			{
+				PX_ERROR("Invalid Object struct");
+			}
+		}
+	}
+	else
+	{
+		if (pObject->pPreBrother!=PX_NULL)
+		{
+			pObject->pPreBrother=pObject->pNextBrother;
+		}
+	}
+
+	// if the parent is null, then the object is a root object
+	if(pParent==PX_NULL){
+		pObject->pParent=PX_NULL;
+		pObject->pNextBrother=PX_NULL;
+		pObject->pPreBrother=PX_NULL;
+	}else{
+		PX_ObjectAddClild(pParent, pObject);
+	}
+}
+
 px_void PX_ObjectDelete( PX_Object *pObject )
 {
 	if (pObject==PX_NULL) 

--- a/kernel/PX_Object.c
+++ b/kernel/PX_Object.c
@@ -532,7 +532,7 @@ px_void PX_ObjectSetParent(PX_Object *pObject, PX_Object *pParent)
 		pObject->pNextBrother=PX_NULL;
 		pObject->pPreBrother=PX_NULL;
 	}else{
-		PX_ObjectAddClild(pParent, pObject);
+		PX_ObjectAddChild(pParent, pObject);
 	}
 }
 

--- a/kernel/PX_Object.h
+++ b/kernel/PX_Object.h
@@ -331,7 +331,7 @@ px_bool		PX_ObjectIsCursorInRegion(PX_Object *Object,PX_Object_Event e);
 px_float	PX_ObjectGetHeight(PX_Object *Object);
 px_float	PX_ObjectGetWidth(PX_Object *Object);
 
-px_void PX_ObjectAddClild(PX_Object *Parent,PX_Object *child);
+px_void PX_ObjectAddChild(PX_Object *Parent,PX_Object *child);
 px_void PX_ObjectUpdate(PX_Object *Object,px_uint elapsed );
 px_void PX_ObjectRender(px_surface *pSurface,PX_Object *Object,px_uint elapsed);
 

--- a/kernel/PX_Object.h
+++ b/kernel/PX_Object.h
@@ -311,6 +311,7 @@ px_void	   PX_ObjectInitialize(px_memorypool *mp,PX_Object *Object,PX_Object *Pa
 px_void    PX_ObjectSetId(PX_Object *pObject,const px_char id[]);
 px_void    PX_ObjectSetUserCode(PX_Object *pObject,px_int user_int);
 px_void    PX_ObjectSetUserPointer(PX_Object *pObject,px_void *user_ptr);
+px_void	   PX_ObjectSetParent(PX_Object *Object,PX_Object *Parent);
 px_void    PX_ObjectDelete(PX_Object *pObject);
 px_void    PX_ObjectDelayDelete(PX_Object* pObject);
 px_void	   PX_ObjectDeleteChilds( PX_Object *pObject );

--- a/kernel/PX_Object_ScrollArea.c
+++ b/kernel/PX_Object_ScrollArea.c
@@ -33,7 +33,7 @@ px_void PX_Object_ScrollArea_EventDispatcher(PX_Object *Object,PX_Object_Event e
 
 px_void  PX_Object_ScrollAreaLinkChild(PX_Object *parent,PX_Object *child)
 {
-	PX_ObjectAddClild(PX_Object_ScrollAreaGetIncludedObjects(parent),child);
+	PX_ObjectAddChild(PX_Object_ScrollAreaGetIncludedObjects(parent),child);
 	PX_Object_ScrollAreaUpdateRange(parent);
 }
 

--- a/kernel/PX_Object_Widget.c
+++ b/kernel/PX_Object_Widget.c
@@ -13,7 +13,7 @@ px_void PX_Object_WidgetFree(PX_Object *pObject)
 
 px_void  PX_Object_WidgetLinkChild(PX_Object *parent,PX_Object *child)
 {
-	PX_ObjectAddClild(PX_Object_WidgetGetRoot(parent),child);
+	PX_ObjectAddChild(PX_Object_WidgetGetRoot(parent),child);
 }
 
 px_void PX_Object_WidgetShow(PX_Object *pObject)


### PR DESCRIPTION
This pr does two things.

1. it renames `PX_ObjectAddClild` to `PX_ObjectAddChild`.
2. it adds a function `PX_ObjectSetParent(PX_Object *pObject, PX_Object *pParent)`. This function can reset the parent of an initialized object.

https://github.com/blueloveTH/pype/blob/684ada87d6046ec7fb7dcd4abf1689d6c49c02cb/project/GameObject.h#L149
A simple test here, it creates some objects and prints the tree structure.
```python
g = GameObject("g#001")
f = GameObject("f#002")
b = GameObject("b#003")
c = GameObject("c#004")
d = GameObject("d#005")
e = GameObject("e#006")
b.parent = g
d.parent = b
e.parent = c
c.parent = b
print_tree()
```

```
g#001
    |-- b#003
        |-- d#005
        |-- c#004
            |-- e#006
f#002
```

Move `c` to root node.
```python
c.parent = None
print_tree()
```
```
g#001
    |-- b#003
        |-- d#005
f#002
c#004
    |-- e#006
```

Move `g` to `e`'s child.
```python
g.parent = e
print_tree()
```

```
f#002
c#004
    |-- e#006
        |-- g#001
            |-- b#003
                |-- d#005
```

The `print_tree`'s impl:
```python
def traverse(curr=None, depth=0):
    if curr is None:
        curr = _root
        depth = -1
    else:
        yield curr, depth
    for child in curr.children:
        yield from traverse(child, depth+1)

def print_tree():
    for curr, depth in traverse():
        indent = '    ' * depth
        prefix = '|-- ' if depth > 0 else ''
        print(indent + prefix + curr.name)
```