### PR TITLE
core/PX_Delaunay: Prevent division by zero and avoid integer division…

### DIFF
--- a/core/PX_Delaunay.c
+++ b/core/PX_Delaunay.c
@@ -15,7 +15,9 @@ px_bool PX_DelaunaryVerifyCircle(px_point2D pt[],px_int p1,px_int p2,px_int p3)
 	{
 		return PX_FALSE;
 	}
-	if ((pt[p1].y-pt[p2].y)/(pt[p1].x-pt[p2].x)==(pt[p1].y-pt[p3].y)/(pt[p1].x-pt[p3].x))
+	// Determine collinearity
+	// replace y1/x1 = y2/x2 => x1*y2 = x2*y1. when x1 = 0 or x2 = 0 it still works
+	if((pt[p1].x-pt[p2].x)*(pt[p1].y-pt[p3].y) == (pt[p1].y-pt[p2].y)*(pt[p1].x-pt[p3].x))
 	{
 		return PX_FALSE;
 	}


### PR DESCRIPTION
发现在判断是否共线的时候使用了整数除法，并且被除数有可能是0
改为使用乘法判断共线。
在研究大佬live2d算法时候偶然发现的hhh