### PR TITLE
change variable definition position for compatible with C89

### DIFF
--- a/core/PX_Mp3.c
+++ b/core/PX_Mp3.c
@@ -379,8 +379,9 @@ static px_int L3_read_side_info(bs_t* bs, L3_gr_info_t* gr, const px_byte* hdr)
 
     px_uint tables, scfsi = 0;
     px_int main_data_begin, part_23_sum = 0;
-    px_int sr_idx = HDR_GET_MY_SAMPLE_RATE(hdr); sr_idx -= (sr_idx != 0);
+    px_int sr_idx = HDR_GET_MY_SAMPLE_RATE(hdr);
     px_int gr_count = HDR_IS_MONO(hdr) ? 1 : 2;
+    sr_idx -= (sr_idx != 0);
 
     if (HDR_TEST_MPEG1(hdr))
     {

--- a/core/PX_TriangleCross.c
+++ b/core/PX_TriangleCross.c
@@ -1,4 +1,4 @@
-﻿#include "PX_Typedef.h"
+#include "PX_Typedef.h"
 
 
 static void px_triangle_copy_point( px_point2D* p, px_point f )

--- a/kernel/PX_CanvasVM.c
+++ b/kernel/PX_CanvasVM.c
@@ -1280,12 +1280,12 @@ px_bool PX_CanvasVMExecuteShell(PX_CanvasVM* pCanvasVM)
 px_int PX_CanvasVMGetLastShellIP(PX_CanvasVM* pCanvasVM)
 {
 	px_int ip;
+	PX_CanvasVMShell_Header* pheader;
 	if (pCanvasVM->shell.usedsize == 0)
 	{
 		return -1;
 	}
 	ip = 0;
-	PX_CanvasVMShell_Header* pheader;
 	while (PX_TRUE)
 	{
 		pheader = (PX_CanvasVMShell_Header*)(pCanvasVM->shell.buffer + ip);

--- a/kernel/PX_World.c
+++ b/kernel/PX_World.c
@@ -1303,6 +1303,7 @@ px_void PX_WorldFree(PX_World *pw)
 {
 	PX_WorldObject *pwo;
 	px_int i;
+    PX_RBNode *pNode;
 	for (i=0;i<pw->pObjects.size;i++)
 	{
 		pwo=PX_VECTORAT(PX_WorldObject,&pw->pObjects,i);
@@ -1324,7 +1325,7 @@ px_void PX_WorldFree(PX_World *pw)
 	PX_VectorFree(&pw->pObjects);
 	PX_VectorFree(&pw->pNewObjects);
 	
-	PX_RBNode* pNode = PX_MapFirst(&pw->classes);
+	pNode = PX_MapFirst(&pw->classes);
 	while (pNode)
 	{
 		MP_Free(pw->mp, pNode->_ptr);


### PR DESCRIPTION
move variable definition ahead for compatible with C89;
change file core/PX_TriangleCross.c encoding from UTF-8-BOM to UTF-8