### PR TITLE
optimize readme and doc again

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,30 @@
   </a>
 </p>
 
-PainterEngine 是一个由 C 语言编写的跨平台图形引擎, 支持 Windows/Linux/iOS/Android/WebAssembly 甚至无操作系统的裸嵌入式平台, 它基于组件化的设计模式, 即使是 C 语言初学者, 也可以在几分钟内掌握它的使用, [PainterEngine Make](https://www.painterengine.com/) 允许您一键将您的 PainterEngine 项目编译到多个平台.
-它涵盖了基础数据结构、图形学、声学、数字信号处理、编译原理、虚拟机系统、密码学、人机交互、游戏引擎、FPGA-GPU 图形 IP 设计等多个领域, 你既可以用它制作微应用, 也可以将它作为学习项目。
+PainterEngine 是一个由 C 语言编写的跨平台图形引擎，支持 Windows/Linux/iOS/Android/WebAssembly 甚至无操作系统的裸嵌入式平台，它基于组件化的设计模式，即使是 C 语言初学者，也可以在几分钟内掌握它的使用，[PainterEngine Make](https://www.painterengine.com/) 允许您一键将您的 PainterEngine 项目编译到多个平台。
+它涵盖了基础数据结构、图形学、声学、数字信号处理、编译原理、虚拟机系统、密码学、人机交互、游戏引擎、FPGA-GPU 图形 IP 设计等多个领域，你既可以用它制作微应用，也可以将它作为学习项目。
 
-现在了解并使用 PainterEngine---->
-*__[PainterEngine 快速入门手册(中文版)](./documents/PainterEngine%20the%20book.md)__*
+现在了解并使用 PainterEngine $\longrightarrow$
+*__[PainterEngine 快速入门手册（中文版）](./documents/PainterEngine_the_book_zh-CN.md)__*
 
-PainterEngine is a cross-platform graphics engine written in C language, with support for Windows, Linux, iOS, Android, WebAssembly, and even bare-metal embedded platforms without OS. It is built on a component-based design pattern, making it accessible to even C language beginners . [PainterEngine Make](https://www.painterengine.com/) enables you to compile your PainterEngine project for multiple platforms with just one click.
+PainterEngine is a cross-platform graphics engine written in C language, with support for Windows, Linux, iOS, Android, WebAssembly, and even bare-metal embedded platforms without OS. It is built on a component-based design pattern, making it accessible to even C language beginners. [PainterEngine Make](https://www.painterengine.com/) enables you to compile your PainterEngine project for multiple platforms with just one click.
 It covers various fields including basic data structures, graphics, acoustics, digital signal processing, compiler design, virtual machine systems, cryptography, human-computer interaction, game engines, FPGA-GPU graphics acceleration, and more. You can use it to create mini-applications or as a learning project for acquiring knowledge.
+
+Now, learn and use PainterEngine $\longrightarrow$
+*__[PainterEngine Quick Start Guide (English Version)](./documents/PainterEngine_the_book_en.md)__*
 
 ## 30 秒速览 PainterEngine
 
 ## 30-Second Quick Start Guide to PainterEngine
 
-将 PainterEngine 引入到您的 C/C++ 项目中, 仅仅需要 `#include "PainterEngine.h"`.
+将 PainterEngine 引入到您的 C/C++ 项目中，仅仅需要 `#include "PainterEngine.h"`。
 
 To incorporate PainterEngine into your project, all you need is:
 ```c
 #include "PainterEngine.h"
 ```
 
-使用 `PainterEngine_Initialize`, 快速创建一个图形化的交互式界面:
+使用 `PainterEngine_Initialize`，快速创建一个图形化的交互式界面：
 
 Utilize `PainterEngine_Initialize` to swiftly create a graphical interactive interface:
 ```c
@@ -36,7 +39,7 @@ int main()
 }
 ```
 
-创建组件, 或者...创造自己的组件:
+创建组件，或者……创造自己的组件：
 
 Create components or even craft your own:
 
@@ -56,7 +59,7 @@ int main()
   <img src="images/firework.png" alt="PainterEngine firework">
 </p>
 
-使用 [PainterEngine Make](https://www.painterengine.com/) 快速将您的项目编译到 Windows, Linux, WebAssembly, Android 等任意平台, 一键编译部署, 源码无需修改, 零成本移植.
+使用 [PainterEngine Make](https://www.painterengine.com/) 快速将您的项目编译到 Windows、Linux、WebAssembly、Android 等任意平台，一键编译部署，源码无需修改，零成本移植。
 
 Use ["PainterEngine Make"](https://www.painterengine.com/) to quickly compile and deploy your project to various platforms such as Windows, Linux, WebAssembly, Android, and more. One-click compilation and deployment, with no need to modify the source code, enabling seamless portability at zero cost.
 
@@ -72,20 +75,21 @@ Use ["PainterEngine Make"](https://www.painterengine.com/) to quickly compile an
   </a>
 </p>
 
-## 快速开发, 无缝迁移
+## 快速开发，无缝迁移
+
 ## Swift development and smooth transitions
 
-如果您不需要 PainterEngine Make 提供的一键编译功能, 希望使用自己常用的 IDE 开发 PainterEngine 程序或组件, 您只需要:
+如果您不需要 PainterEngine Make 提供的一键编译功能，希望使用自己常用的 IDE 开发 PainterEngine 程序或组件，您只需要：
 
-1. 将 "PainterEngine/core", "PainterEngine/kernel", "PainterEngine/runtime" 的所有代码, 添加到您的项目中. 
+1. 将 "PainterEngine/core"、"PainterEngine/kernel"、"PainterEngine/runtime" 的所有代码，添加到您的项目中。 
 
-2. 在 "PainterEngine/platform" 中选择您的工作平台(例如 Windows 中选择 "PainterEngine/platform/windows"), 并将对应文件夹中的所有代码添加到您的项目中.
+2. 在 "PainterEngine/platform" 中选择您的工作平台（例如 Windows 中选择 "PainterEngine/platform/windows"），并将对应文件夹中的所有代码添加到您的项目中。
 
-3. 将 PainterEngine 所在目录, 添加到包含目录中. 
+3. 将 PainterEngine 所在目录添加到包含目录中。
 
-4. 将您的代码添加进项目中.
+4. 将您的代码添加进项目中。
 
-即可使用您的 IDE 完成 PainterEngine 的编译, PainterEngine 库将尽力保证所有平台的的运行结果一致性, 在 Windows 上开发, 同样在 Android/web/Linux/iOS/... 中能够得到一致的结果.
+即可使用您的 IDE 完成 PainterEngine 的编译，PainterEngine 库将尽力保证所有平台的的运行结果一致性，在 Windows 上开发，同样在 Android/web/Linux/iOS/…… 中能够得到一致的结果。
 
 If you don't need the one-key compilation feature provided by PainterEngine Make and prefer to develop PainterEngine programs or components using your preferred IDE, you just need to:
 
@@ -99,35 +103,33 @@ If you don't need the one-key compilation feature provided by PainterEngine Make
 
 You can now use your IDE to compile PainterEngine with these steps. PainterEngine library will strive to ensure consistent results across all platforms. What you develop on Windows will yield consistent results on Android, web, Linux, iOS, and more.
 
-## 不仅是图形库, 更是应用程序框架
+## 不仅是图形库，更是应用程序框架
 
-## Not just a graphics library but also an application framework.
+## Not just a graphics library but also an application framework
 
 | Functions             | Support                                                      | Description                                                                       |
 | --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------          |
 | 内存池                 | alloc/free                                                   | 平台无关的内存池实现                              |
 | 数学库               | sin/cos/tan/arcsin/log/exp/relu/...                | 绝大部分 C 标准数学库的完整实现                          |
-| 信号处理               | dft/dct/fft/dwt/window functions/mfcc/...                | 傅里叶/余弦/小波变换, 常用窗函数, mfcc 等特征采集算法...等等信号处理相关基础函数及上层特征采集算法                         |
+| 信号处理               | dft/dct/fft/dwt/window functions/mfcc/...                | 傅里叶/余弦/小波变换、常用窗函数、mfcc 等特征采集算法……等等信号处理相关基础函数及上层特征采集算法                         |
 | 数据结构               | string/vector/list/map/stack/fifo/circular-buffer/...                | 平台无关的数据结构算法实现                          |
 | 密码学               | curve25519/AES/SHAx/MD5/...                | 包含常用的密钥对称算法及密钥协商算法                          |
 | 图片支持               | PNG/JPG/GIF/BMP                                              | 支持 PNG/JPG/GIF/BMP 解码及 PNG 编码           |
-| 音频支持               | WAV/MP3                                              | 支持 Wav, Mp3 解码及 Wav 编码|
-| 字模支持               | ttf                                              | 支持 ttf 字模文件(由 stb_truetype.c 移植而来)|
+| 音频支持               | WAV/MP3                                              | 支持 Wav、Mp3 解码及 Wav 编码|
+| 字模支持               | ttf                                              | 支持 ttf 字模文件（由 stb_truetype.c 移植而来）|
 | 几何绘制               | Line/Triangle/Rectangle/Circle/Ring/Sector/Rounded/...      | 常用几何光栅化实现                                                                 |
 | 渲染器                | 2D/3D                                                        | 2D/3D 渲染器实现及一个高质量制图引擎                                                 |
 | 动画                  | 2dx/live2D                                                   | 2D 动画和一个类 Live2D 骨骼动画系统                                                  |
-| 声学模型               | mixer/piano/ks                                               | 包含一个混音器实现, 一个相位声码器, 一个物理建模的钢琴及 karplus-strong 合成的拨弦模型, 直接合成 PCM 音频流   |
-| 脚本引擎               | Compiler/VM/Debugger                                         | 一个完整的脚本引擎, 包含编译器虚拟机调试器                                           |
+| 声学模型               | mixer/piano/ks                                               | 包含一个混音器实现、一个相位声码器、一个物理建模的钢琴及 karplus-strong 合成的拨弦模型，直接合成 PCM 音频流   |
+| 脚本引擎               | Compiler/VM/Debugger                                         | 一个完整的脚本引擎，包含编译器虚拟机调试器                                           |
 | UI 框架                 | button/radio/image/edit/label/list/...                       | UI 框架实现                                                                        |
 | 协议                   | MQTT/MODBUS/Game-network-synchronization                     | 常用的通讯协议                                                                    |
 | 游戏引擎               |                                                              | 集成一个游戏世界框架                                                               |
-| FPGA-GPU               |2D accelerator                                               | 实现了基于 FPGA 的 GPU 图形加速器, 能够为 PainterEngine 提供不低于 50Mpps 的 2D Blender 及图元光栅化加速, 支持 HDMI 输出, 目前已在 zynq7000 系列 Soc 上完成验证|
+| FPGA-GPU               |2D accelerator                                               | 实现了基于 FPGA 的 GPU 图形加速器，能够为 PainterEngine 提供不低于 50Mpps 的 2D Blender 及图元光栅化加速，支持 HDMI 输出，目前已在 zynq7000 系列 Soc 上完成验证|
 
-还有更多探索...
+还有更多探索……
 
-///////////////////////////////////////////////////////////////////////////////
-
-
+---
 
 | functions             | support                                                      | Description                                                                       |
 | --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------          |
@@ -155,7 +157,7 @@ Many more to explore...
 
 ## The FPGA-GPU Graphics Acceleration Solution
 
-提供一个基于 FPGA 的 GPU IP 核, 已在 Zynq7020 上完成功能验证, 提供不低于 50Mpps 的 2D Blender 图形渲染加速, 支持 HDMI 输出, 目前已在 zynq7000 系列 Soc 上完成验证.
+提供一个基于 FPGA 的 GPU IP 核，已在 Zynq7020 上完成功能验证，提供不低于 50Mpps 的 2D Blender 图形渲染加速，支持 HDMI 输出，目前已在 zynq7000 系列 SoC 上完成验证。
 
 A GPU IP core based on FPGA has been developed and functionally verified on the Zynq 7020 platform. It provides 2D Blender graphics rendering acceleration with a performance of no less than 50Mpps (Million pixels per second) and supports HDMI output. This solution has been successfully validated on the Zynq 7000 series SoC.
 
@@ -165,13 +167,13 @@ A GPU IP core based on FPGA has been developed and functionally verified on the 
 
 <p align="center"><img src="images/gpu_demo2.png" alt="PainterEngine designer"></p>
 
-## 组件化开发, 支持设计器模式, 简单的不能再简单
+## 组件化开发，支持设计器模式，简单的不能再简单
 
 ## Component-based development with support for a designer mode, making it as simple as it gets
 
 <p align="center"><img src="images/designer.png" alt="PainterEngine designer"></p>
 
-## 海量组件, 创意无界
+## 海量组件，创意无界
 
 ## An abundance of components to unleash your creativity without limitations.
 
@@ -183,9 +185,9 @@ A GPU IP core based on FPGA has been developed and functionally verified on the 
 
 <p align="center"><img width="600" src="images/l2d.png" alt="PainterEngine market"></p>
 
-### 现在, 访问 PainterEngine.com, 参与建设
+### 现在，访问 PainterEngine.com，参与建设
 
-### Now, join the PainterEngine.com contribute to its development.
+### Now, join the PainterEngine.com contribute to its development
 
 <p align="center">
 <img src="documents/assets/mini/1.png" alt="logo">

--- a/documents/PainterEngine_the_book_zh-CN.md
+++ b/documents/PainterEngine_the_book_zh-CN.md
@@ -1,24 +1,24 @@
-# The Book Of PainterEngine 
+# PainterEngine 快速入门手册
 
-## 导言 
+## 导言
 
-欢迎开始我们的 PainterEngine 的第一课, 但在此之前相信大家并不清楚 PainterEngine 到底是一个做什么的, 也许您已经在互联网上对它有些许印象, 它或许是一个图形库, 或者是游戏引擎, 你可能已经看过了基于它的关于声学、密码学、神经网络、数字信号处理、编译器、虚拟机等等相关内容，甚至还有一个基于 FPGA 的 GPU IP 核。所以你可能认为它是一个集合了各式各样程式库的大混合体。
+欢迎开始我们的 PainterEngine 的第一课，但在此之前相信大家并不清楚 PainterEngine 到底是一个做什么的，也许您已经在互联网上对它有些许印象，它或许是一个图形库，或者是游戏引擎，你可能已经看过了基于它的关于声学、密码学、神经网络、数字信号处理、编译器、虚拟机等等相关内容，甚至还有一个基于 FPGA 的 GPU IP 核。所以你可能认为它是一个集合了各式各样程式库的大混合体。
 
 以上都对，但总的来说，我更倾向于将 PainterEngine 认为是一个应用程序框架，它诞生之初的最终原因，是为了解决程序开发过程中极其麻烦的三方库（甚至是标准库）依赖问题，最大程度简化程序的平台移植和编译难度。
 
 因此如你所见，PainterEngine 的编译不会让你陷入各式各样的三方依赖中，目前它可以在几乎所有提供 C 语言编译环境的平台上运行，它没有操作系统及文件系统依赖，可以运行在裸 MCU 环境中，甚至 PainterEngine 的官网首页也是由 PainterEngine 开发的。
 
-PainterEngine 始终遵循着最简设计原则，而 PainterEngine 使用了 C 语言作为其主要开发语言，而其内置的脚本引擎，同样最大程度的兼容 C 语言语法，并对 C 语言的类型做了少量的抽象及泛化，进一步减少它的上手及使用门槛。C 语言作为一门历史悠久的语言，如今几乎是各大工科类专业必学的一门课程，其在计算机编程开发的发展中，始终保持着强大的竞争力及广泛认可，并成为了几乎所有硬件平台，所需要并提供支持的事实标准。C 语言在学习与开发成本维持着一个微妙的平衡，因此你可以在很短的时间学习并上手 C 语言，配合 PainterEngine，你就能将你的程序运行在全平台，并深刻感受编程艺术所带来的魅力。
+PainterEngine 始终遵循着最简设计原则，而 PainterEngine 使用了 C 语言作为其主要开发语言，而其内置的脚本引擎同样最大程度的兼容 C 语言语法，并对 C 语言的类型做了少量的抽象及泛化，进一步减少它的上手及使用门槛。C 语言作为一门历史悠久的语言，如今几乎是各大工科类专业必学的一门课程，其在计算机编程开发的发展中，始终保持着强大的竞争力及广泛认可，并成为了几乎所有硬件平台所需要并提供支持的事实标准。C 语言在学习与开发成本维持着一个微妙的平衡，因此你可以在很短的时间学习并上手 C 语言，配合 PainterEngine，你就能将你的程序运行在全平台，并深刻感受编程艺术所带来的魅力。
 
 PainterEngine 同样经历了近乎十年的发展，但在很长的一段时间，其作为一个私用库较少在公开领域正式推广，一个是在其迭代的过程中，很多的接口和函数仍然未稳定，我们必须在长期的实践中，保证接口设计的合理性和易用性，区分哪些是“真正有用且好用”的，哪些只是“灵光一闪看上去光鲜亮丽，其实没啥用的”。因此 PainterEngine 在很长一段时间，都没有详细且稳定的文档，而经过那么多年的迭代，我们最终可以将那些稳定、好用、简单易学的设计公布出来，并最终给大家带来这篇文档。
 
-最后，我并不希望将导言写的太长，是时候马上切入主题了，我们将从 PainterEngine 的环境搭建开始 PainterEngine 的第一课，如果你有相关问题或发现了 bug，你可以在 PainterEngine 论坛中提问，或者直接将问题发送到 matrixcascade@gmail.com, 我将在第一时间给你反馈。
+最后，我并不希望将导言写的太长，是时候马上切入主题了，我们将从 PainterEngine 的环境搭建开始 PainterEngine 的第一课，如果你有相关问题或发现了 bug，你可以在 PainterEngine 论坛中提问，或者直接将问题发送到 matrixcascade@gmail.com，我将在第一时间给你反馈。
 
 ![](assets/mini/1.png)
 
 ## 1. 一个最简单的 PainterEngine 程序
 
-在搭建开发环境之前，让我们先编写一个最简单的 PainterEngine 程序，让我们新建一个 `main.c` 文件(文件名可以任意取), 然后在其中输入以下代码：
+在搭建开发环境之前，让我们先编写一个最简单的 PainterEngine 程序，让我们新建一个 `main.c` 文件（文件名可以任意取），然后在其中输入以下代码：
 
 ```c
 #include "PainterEngine.h"
@@ -29,25 +29,25 @@ int main()
 }
 ```
 
-这是一个相当简单的 PainterEngine 程序, 简单来说, 在第一行我们使用 `include` 将 PainterEngine 的头文件包含了进来, 在 `main` 函数中, 我们使用 `PainterEngine_Initialize` 对 PainterEngine 进行初始化操作, `PainterEngine_Initialize` 接受 2 个参数, 分别是窗口(或者是屏幕)的宽度和高度, 在程序运行后, 你大概能看到这样的结果：
+这是一个相当简单的 PainterEngine 程序，简单来说，在第一行我们使用 `include` 将 PainterEngine 的头文件包含了进来，在 `main` 函数中，我们使用 `PainterEngine_Initialize` 对 PainterEngine 进行初始化操作，`PainterEngine_Initialize` 接受 2 个参数，分别是窗口（或者是屏幕）的宽度和高度，在程序运行后，你大概能看到这样的结果：
 
 ![](assets/img/1.1.png)
 
-当然, 现在我们还没有使用 PainterEngine 在窗口上绘制任何东西, 因此你看到的是一个空白的画面。需要注意的是, 在 PainterEngine 的框架中, `main` 函数返回后, 程序并不会立即结束, 实际上在 `PainterEngine.h` 中, `main` 函数被替换成了 `px_main`, 真正的 `main` 函数在 `px_main.c` 中实现, 但用户目前可以用不着关心这个, 只需要记住 `main` 函数返回后, 程序仍然是在正常运行的。如果你希望退出程序, 你可以自行调用 C 语言的 `exit` 函数, 但在 PainterEngine 中的很多时候你并不需要这么做, 因为像在嵌入式单片机、网页、驱动程序中，大部分是用不到退出这个概念的，哪怕是在 Android，iOS 平台，绝大部分时候也不需要你在程序中设计退出功能。
+当然，现在我们还没有使用 PainterEngine 在窗口上绘制任何东西，因此你看到的是一个空白的画面。需要注意的是，在 PainterEngine 的框架中，`main` 函数返回后，程序并不会立即结束，实际上在 `PainterEngine.h` 中，`main` 函数被替换成了 `px_main`，真正的 `main` 函数在 `px_main.c` 中实现，但用户目前可以用不着关心这个，只需要记住 `main` 函数返回后，程序仍然是在正常运行的。如果你希望退出程序，你可以自行调用 C 语言的 `exit` 函数，但在 PainterEngine 中的很多时候你并不需要这么做，因为像在嵌入式单片机、网页、驱动程序中，大部分是用不到退出这个概念的，哪怕是在 Android，iOS 平台，绝大部分时候也不需要你在程序中设计退出功能。
 
 ## 2. 编译 PainterEngine 程序
 
 ### 使用 PainterEngine Make 编译
 
-如果你想要编译 PainterEngine 的项目文件，最简单的做法是使用 PainterEngine Make，这是一款你能够在 PainterEngine.com 中下载到的一款编译工具, 你可以在主页下方找到它的下载按钮:
+如果你想要编译 PainterEngine 的项目文件，最简单的做法是使用 PainterEngine Make，这是一款你能够在 PainterEngine.com 中下载到的一款编译工具，你可以在主页下方找到它的下载按钮：
 
 ![](assets/img/2.1.png)
 
-解压缩以后, 直接运行 PainterEngine make.exe, 你就可以看到如下界面：
+解压缩以后，直接运行 PainterEngine make.exe，你就可以看到如下界面：
 
 ![](assets/img/2.2.png)
 
-然后选择你需要编译的平台, 然后选中我们之前创建的那个 C 语言代码文件：
+然后选择你需要编译的平台，然后选中我们之前创建的那个 C 语言代码文件：
 
 ![](assets/img/2.3.png)
 
@@ -57,13 +57,13 @@ int main()
 
 ### 使用 Visual Studio Code 编译
 
-要使用 Visual Studio Code 进行编译, 你需要确保你已经安装好了 Visual Studio Code 的 C 语言开发环境, 这块步骤我们略过, 因为在互联网上已经有相当多这样的教程了。
+要使用 Visual Studio Code 进行编译，你需要确保你已经安装好了 Visual Studio Code 的 C 语言开发环境，这块步骤我们略过，因为在互联网上已经有相当多这样的教程了。
 
 然后请到 PainterEngine 中，下载 PainterEngine 的源码：
 
 ![](assets/img/2.5.png)
 
-将下载好的源码解压到计算机的某个目录下，然后你需要记录这个目录的位置，并在 Windows 的环境变量中新建一个名叫 `PainterEnginePath` 的变量, 并将它赋值为 PainterEngine 库所在目录：
+将下载好的源码解压到计算机的某个目录下，然后你需要记录这个目录的位置，并在 Windows 的环境变量中新建一个名叫 `PainterEnginePath` 的变量，并将它赋值为 PainterEngine 库所在目录：
 
 ![](assets/img/2.6.png)
 
@@ -75,7 +75,7 @@ int main()
 
 ![](assets/img/2.9.png)
 
-然后请用 Visual Studio Code 打开 `main.c` 文件, 然后你就可以进行编译运行了：
+然后请用 Visual Studio Code 打开 `main.c` 文件，然后你就可以进行编译运行了：
 
 ![](assets/img/2.10.png)
 
@@ -83,7 +83,7 @@ int main()
 
 ### 使用 Visual Studio 编译
 
-当然, 如果你需要使用完整的 IDE 开发体验, 那么仍然建议使用 Visual Studio 进行开发编译。要使用 Visual Studio 开发 PainterEngine，你需要打开 Visual Studio 创建一个空项目：
+当然，如果你需要使用完整的 IDE 开发体验，那么仍然建议使用 Visual Studio 进行开发编译。要使用 Visual Studio 开发 PainterEngine，你需要打开 Visual Studio 创建一个空项目：
 
 ![](assets/img/2.12.png)
 
@@ -103,7 +103,7 @@ int main()
 
 ![](assets/img/2.17.png)
 
-打开 `项目` → `属性` → `VC++目录` 中, 把 PainterEngine 的所在目录包含进来：
+打开 `项目` → `属性` → `VC++目录` 中，把 PainterEngine 的所在目录包含进来：
 
 ![](assets/img/2.18.png)
 
@@ -111,73 +111,74 @@ int main()
 
 ![](assets/img/2.20.png)
 
-特别需要注意检查配置和 Visual Stdio 的当前配置是否是一致的, 这是一个很容易出错的点：
+特别需要注意检查配置和 Visual Stdio 的当前配置是否是一致的，这是一个很容易出错的点：
 
 ![](assets/img/2.21.png)
 
-最后, 你就可以编译运行调试了：
+最后，你就可以编译运行调试了：
 
 ![](assets/img/2.22.png)
 
 ## 3. PainterEngine 第一课，输出文字“Hello PainterEngine”
 
-正如你所见，PainterEngine 是一个图形化应用程序框架, 但依据传统, 我们的第一课仍然是如何用 PainterEngine 输出文字, 但多数时候, 与其说是输出文字不如说是绘制文字。使用 PainterEngine 绘制文字非常简单, 查看如下代码：
+正如你所见，PainterEngine 是一个图形化应用程序框架，但依据传统，我们的第一课仍然是如何用 PainterEngine 输出文字，但多数时候，与其说是输出文字不如说是绘制文字。使用 PainterEngine 绘制文字非常简单，查看如下代码：
 
 ```c
 #include "PainterEngine.h"
 int main()
 {
-    PainterEngine_Initialize(800,480);
-//PainterEngine_DrawText
-//参数1：x坐标
-//参数2：y坐标
-//参数3：文本内容
-//参数4：对齐方式
-//参数5：颜色
+    PainterEngine_Initialize(800, 480);
+	// PainterEngine_DrawText
+	// 参数1：x坐标
+	// 参数2：y坐标
+	// 参数3：文本内容
+	// 参数4：对齐方式
+	// 参数5：颜色
     PainterEngine_DrawText(400, 240, "Hello PainterEngine", PX_ALIGN_CENTER, PX_COLOR(255, 255, 0, 0));
     return 1;
 }
 ```
-我们主要看 `PainterEngine_DrawText` 函数, 这是一个文本绘制函数, 它有 5 个参数, 当你运行程序后, 你将看到这个结果:
+
+我们主要看 `PainterEngine_DrawText` 函数，这是一个文本绘制函数，它有 5 个参数，当你运行程序后，你将看到这个结果：
 
 ![](assets/img/3.1.png)
 
-整个函数非常好理解, 但这里我们详细解释一下 `对齐方式` 和 `颜色` 这两个参数的意义, 因为在后续的教程中, 这两个概念会经常被提及:
+整个函数非常好理解，但这里我们详细解释一下 `对齐方式` 和 `颜色` 这两个参数的意义，因为在后续的教程中，这两个概念会经常被提及：
 
-其中, `对齐方式` 就是对应内容绘制在屏幕上的对齐方式, PainterEngine 中的对齐方式包含以下几种格式：
+其中，`对齐方式` 就是对应内容绘制在屏幕上的对齐方式，PainterEngine 中的对齐方式包含以下几种格式：
 
 ```c
 typedef enum
 {
-	PX_ALIGN_LEFTTOP = 7,//左上角对齐
-	PX_ALIGN_MIDTOP = 8,//中上对齐
-	PX_ALIGN_RIGHTTOP = 9,//右上角对齐
-	PX_ALIGN_LEFTMID = 4,//左中对齐
-	PX_ALIGN_CENTER = 5,//居中对齐
-	PX_ALIGN_RIGHTMID = 6,//右中对齐
-	PX_ALIGN_LEFTBOTTOM = 1,//左下角对齐
-	PX_ALIGN_MIDBOTTOM = 2,//中底对齐
-	PX_ALIGN_RIGHTBOTTOM = 3,//右下角对齐
+	PX_ALIGN_LEFTTOP = 7,     // 左上角对齐
+	PX_ALIGN_MIDTOP = 8,      // 中上对齐
+	PX_ALIGN_RIGHTTOP = 9,    // 右上角对齐
+	PX_ALIGN_LEFTMID = 4,     // 左中对齐
+	PX_ALIGN_CENTER = 5,      // 居中对齐
+	PX_ALIGN_RIGHTMID = 6,    // 右中对齐
+	PX_ALIGN_LEFTBOTTOM = 1,  // 左下角对齐
+	PX_ALIGN_MIDBOTTOM = 2,   // 中底对齐
+	PX_ALIGN_RIGHTBOTTOM = 3, // 右下角对齐
 }PX_ALIGN;
 ```
 
-这个对齐方式的枚举类型是设计过的, 你可以直接看看你数字小键盘, 其对齐方式和数字小键盘的数值是对应关系。
+这个对齐方式的枚举类型是设计过的，你可以直接看看你数字小键盘，其对齐方式和数字小键盘的数值是对应关系。
 
-而 `颜色格式` 则是一个被定义为 `px_color` 的结构体, 这个结构体有 4 个字节, 内部有 4 个成员变量 a、r、g、b，分别代表颜色的透明度、红色通道、绿色通道和蓝色通道，每一个分量的取值范围都是 0-255，例如红色，这个数值越大，这个颜色就越红。
+而 `颜色格式` 则是一个被定义为 `px_color` 的结构体，这个结构体有 4 个字节，内部有 4 个成员变量 a、r、g、b，分别代表颜色的透明度、红色通道、绿色通道和蓝色通道，每一个分量的取值范围都是 0-255，例如红色，这个数值越大，这个颜色就越红。
 
-因此，你可以看到，在上面的示范代码中，我们绘制了一个红色的文本 `Hello PainterEngine`。现在让我们试试中文, 修改上面的代码, 改为下面这种格式：
+因此，你可以看到，在上面的示范代码中，我们绘制了一个红色的文本 `Hello PainterEngine`。现在让我们试试中文，修改上面的代码，改为下面这种格式：
 
 ```c
 #include "PainterEngine.h"
 int main()
 {
-    PainterEngine_Initialize(800,480);
-//PainterEngine_DrawText
-//参数1：x坐标
-//参数2：y坐标
-//参数3：文本内容
-//参数4：对齐方式
-//参数5：颜色
+    PainterEngine_Initialize(800, 480);
+    // PainterEngine_DrawText
+    // 参数1：x坐标
+    // 参数2：y坐标
+    // 参数3：文本内容
+    // 参数4：对齐方式
+    // 参数5：颜色
     PainterEngine_DrawText(400, 240, "你好PainterEngine", PX_ALIGN_CENTER, PX_COLOR(255, 255, 0, 0));
     return 1;
 }
@@ -185,14 +186,14 @@ int main()
 
 ![](assets/img/3.2.png)
 
-但是, 中文却不能正确显示, 这是因为 PainterEngine 中, 默认只有英文的字模, 如果我们想要支持中文怎么办呢?
-这仍然不困难, 为此, 我们需要先准备一个 ttf 字模文件, 例如在这里, 我准备了一个幼圆字体, 那么, 我只需要将这个字体加载进来就可以了：
+但是，中文却不能正确显示，这是因为 PainterEngine 中，默认只有英文的字模，如果我们想要支持中文怎么办呢？
+这仍然不困难，为此，我们需要先准备一个 TTF 字模文件，例如在这里，我准备了一个幼圆字体，那么，我只需要将这个字体加载进来就可以了：
 
 ```c
 #include "PainterEngine.h"
 int main()
 {
-    PainterEngine_Initialize(800,480);
+    PainterEngine_Initialize(800, 480);
     PainterEngine_LoadFontModule("assets/font.ttf", PX_FONTMODULE_CODEPAGE_GBK, 24);
     PainterEngine_DrawText(400, 240, "你好 PainterEngine", PX_ALIGN_CENTER, PX_COLOR(255, 255, 0, 0));
     return 1;
@@ -201,7 +202,7 @@ int main()
 
 ![](assets/img/3.3.png)
 
-`PainterEngine_LoadFontModule` 的函数的第一个参数是 TTF 字体文件的路径, 相对路径是以 exe 文件所在路径相对的。第二个参数是字符集，在默认情况下, Visual Studio 代码使用的是 GBK 字符集。如果你使用 Visual Studio Code, 那么默认是 UTF8 编码, 第二个参数应该换成 `PX_FONTMODULE_CODEPAGE_GBK`。最后一个参数是字体的大小。
+`PainterEngine_LoadFontModule` 的函数的第一个参数是 TTF 字体文件的路径，相对路径是以 exe 文件所在路径相对的。第二个参数是字符集，在默认情况下，Visual Studio 代码使用的是 GBK 字符集。如果你使用 Visual Studio Code，那么默认是 UTF8 编码，第二个参数应该换成 `PX_FONTMODULE_CODEPAGE_GBK`。最后一个参数是字体的大小。
 
 ## 4. 使用 PainterEngine 绘制几何图形
 
@@ -209,10 +210,10 @@ int main()
 
 `px_void PainterEngine_DrawLine(px_int x1, px_int y1, px_int x2, px_int y2, px_int linewidth, px_color color);`
 这个函数用于绘制一条线段。
-* x1, y1: 线段的起点坐标。
-* x2, y2: 线段的终点坐标。
-* linewidth: 线段的宽度。
-* color: 线段的颜色。
+* x1, y1：线段的起点坐标。
+* x2, y2：线段的终点坐标。
+* linewidth：线段的宽度。
+* color：线段的颜色。
 
 ```c
 #include "PainterEngine.h"
@@ -240,10 +241,10 @@ int main()
 
 `px_void PainterEngine_DrawRect(px_int x, px_int y, px_int width, px_int height, px_color color);`
 这个函数用于绘制一个矩形。
-* x, y: 矩形的左上角坐标。
-* width: 矩形的宽度。
-* height: 矩形的高度。
-* color: 矩形的颜色。
+* x, y：矩形的左上角坐标。
+* width：矩形的宽度。
+* height：矩形的高度。
+* color：矩形的颜色。
 
 ![](assets/img/3.5.png)
 
@@ -272,10 +273,10 @@ int main()
 
 `px_void PainterEngine_DrawCircle(px_int x, px_int y, px_int radius, px_int linewidth, px_color color);`
 这个函数用于绘制一个圆环。
-* x, y: 圆心的坐标。
-* radius: 圆的半径。
-* linewidth: 圆的线宽。
-* color: 圆的颜色。
+* x, y：圆心的坐标。
+* radius：圆的半径。
+* linewidth：圆的线宽。
+* color：圆的颜色。
 
 ```c
 #include "PainterEngine.h"
@@ -302,9 +303,9 @@ int main()
 
 `px_void PainterEngine_DrawSolidCircle(px_int x, px_int y, px_int radius, px_color color);`
 这个函数用于绘制一个实心圆。
-* x, y: 圆心的坐标。
-* radius: 圆的半径。
-* color: 圆的颜色。
+* x, y：圆心的坐标。
+* radius：圆的半径。
+* color：圆的颜色。
 
 ```c
 #include "PainterEngine.h"
@@ -334,12 +335,12 @@ int main()
 `px_void PainterEngine_DrawSector(px_int x, px_int y, px_int inside_radius,px_int outside_radius, px_int start_angle, px_int end_angle, px_color color);`
 这个函数用于绘制一个扇形。
 参数说明：
-* x, y: 扇形的圆心坐标。
-* inside_radius: 扇形的内半径。
-* inside_radius: 扇形的外半径。
-* start_angle: 扇形的起始角度（以度为单位, 支持负角度）。
-* end_angle: 扇形的结束角度（以度为单位, 支持负角度）。
-* color: 扇形的颜色。
+* x, y：扇形的圆心坐标。
+* inside_radius：扇形的内半径。
+* inside_radius：扇形的外半径。
+* start_angle：扇形的起始角度（以度为单位，支持负角度）。
+* end_angle：扇形的结束角度（以度为单位，支持负角度）。
+* color：扇形的颜色。
 
 ```c
 #include "PainterEngine.h"
@@ -367,18 +368,18 @@ int main()
 
 `px_void PainterEngine_DrawPixel(px_int x, px_int y, px_color color);`
 这个函数用于绘制一个像素点。
-* x, y: 像素点的坐标。
-* color: 像素点的颜色。
+* x, y：像素点的坐标。
+* color：像素点的颜色。
 
-这只是绘制一个像素点, 就不放示例图了。
+这只是绘制一个像素点，就不放示例图了。
 
 ## 5. 使用 PainterEngine 绘制图像
 
-使用 PainterEngine 绘制图像仍然很简单, 但在绘制图像之前, 我们需要先加载图片。
+使用 PainterEngine 绘制图像仍然很简单，但在绘制图像之前，我们需要先加载图片。
 
 PainterEngine 可以直接从文件中加载图片，它原生支持 PNG、JPG、BMP、TRAW 四种静态图片格式的加载，为了存储加载的图片，我们需要用到一个叫纹理的结构体。
 
-在 PainterEngine 中，纹理用 `px_texture` 结构体进行描述，因此为了加载纹理，我们需要 `PX_LoadTextureFromFile` 函数, 这个函数是一个三参数的图片文件加载函数。第一个参数是内存池, 在后面的章节, 我将会更详细地讲解 PainterEngine 内存池的内容。在默认情况下, PainterEngine 提供 2 个默认内存池, 一个是 `mp`，一个是 `mp_static`, 其中, 前面的内存池一般用于需要频繁分配释放的元素, 后面的则用于静态资源的存储。在这里因为图片一般是静态资源, 因此填写 `mp_static` 就可以了。第二个参数则是我们纹理结构体的指针，在图片成功加载后，将会初始化这个结构体，并用于保存图片数据。最后一个参数，则是图片文件的所在路径。
+在 PainterEngine 中，纹理用 `px_texture` 结构体进行描述，因此为了加载纹理，我们需要 `PX_LoadTextureFromFile` 函数，这个函数是一个三参数的图片文件加载函数。第一个参数是内存池，在后面的章节，我将会更详细地讲解 PainterEngine 内存池的内容。在默认情况下，PainterEngine 提供 2 个默认内存池，一个是 `mp`，一个是 `mp_static`。其中，前面的内存池一般用于需要频繁分配释放的元素，后面的则用于静态资源的存储。在这里因为图片一般是静态资源，因此填写 `mp_static` 就可以了。第二个参数则是我们纹理结构体的指针，在图片成功加载后，将会初始化这个结构体，并用于保存图片数据。最后一个参数，则是图片文件的所在路径。
 
 在加载文件成功后，我们使用 `PainterEngine_DrawTexture` 函数绘制出来。这是一个四参数的函数：
 
@@ -390,13 +391,13 @@ PainterEngine 可以直接从文件中加载图片，它原生支持 PNG、JPG�
 
 ```c
 #include "PainterEngine.h"
-px_texture mytexture;//纹理
+px_texture mytexture; // 纹理
 int main()
 {
     PainterEngine_Initialize(512, 512);
     if(!PX_LoadTextureFromFile(mp_static,&mytexture,"assets/demo.png"))
 	{
-        //加载纹理失败
+        // 加载纹理失败
 		return 0;
 	}
     PainterEngine_DrawTexture(&mytexture, 0, 0, PX_ALIGN_LEFTTOP);
@@ -410,7 +411,7 @@ int main()
 
 ## 6. PainterEngine 内存池管理机制
 
-因为 PainterEngine 是无系统及标准库依赖的, 因此在 PainterEngine 中, 必须独立于系统及标准库的内存管理机制, 实现 PainterEngine 内部的内存管理系统。因此 PainterEngine 使用了内存池作为动态的内存管理系统。
+因为 PainterEngine 是无系统及标准库依赖的，因此在 PainterEngine 中，必须独立于系统及标准库的内存管理机制，实现 PainterEngine 内部的内存管理系统。因此 PainterEngine 使用了内存池作为动态的内存管理系统。
 
 PainterEngine 内存池实现方式同样很简洁，为了使用内存，你必须预先准备一段可用的内存空间，作为内存池管理的内存空间，例如在下面的代码中，我们可以用 C 语言定义一个较大的全局数组，然后用这个数组空间作为内存池的分配空间：
 
@@ -421,13 +422,13 @@ int main()
 {
     px_memorypool mp;
     px_void* myalloc;
-    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache));//创建内存池
-    myalloc=MP_Malloc(&mp, 1024);//在内存池中分配1024字节
+    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache)); // 创建内存池
+    myalloc=MP_Malloc(&mp, 1024); // 在内存池中分配1024字节
     return 1;
 }
 ```
 
-需要注意的是, **_使用内存池分配的空间, 会略小于分配给内存池的空间。如果你分配的空间超出了内存池, 将会导致一个停机错误。_**
+需要注意的是，**_使用内存池分配的空间，会略小于分配给内存池的空间。如果你分配的空间超出了内存池，将会导致一个停机错误。_**
 
 ```c
 #include "PainterEngine.h"
@@ -436,15 +437,15 @@ int main()
 {
     px_memorypool mp;
     px_void* myalloc;
-    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache));//创建内存池
-    myalloc=MP_Malloc(&mp, 1024*1024);//在内存池中分配1024*1024字节，但内存池实际容量小于分配给内存池容量,因此这里内存不足，这里将会进入中断
+    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache)); // 创建内存池
+    myalloc=MP_Malloc(&mp, 1024*1024); // 在内存池中分配1024*1024字节，但内存池实际容量小于分配给内存池容量,因此这里内存不足，这里将会进入中断
     return 1;
 }
 ```
 
-如果你不希望因为内存池不足导致停机错误, 你可以使用以下两种方式:
+如果你不希望因为内存池不足导致停机错误，你可以使用以下两种方式：
 
-1.你可以设置错误回调, 自行处理内存池的错误：
+1.你可以设置错误回调，自行处理内存池的错误：
 
 ```c
 #include "PainterEngine.h"
@@ -471,14 +472,14 @@ int main()
 {
     px_memorypool mp;
     px_void* myalloc;
-    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache));//创建内存池
-	MP_ErrorCatch(&mp, my_memory_cache_error,0);//设置错误回调
-    myalloc=MP_Malloc(&mp, 1024*1024);//在内存池中分配1024*1024字节
+    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache)); // 创建内存池
+	MP_ErrorCatch(&mp, my_memory_cache_error,0); // 设置错误回调
+    myalloc=MP_Malloc(&mp, 1024*1024); // 在内存池中分配1024*1024字节
     return 1;
 }
 ```
 
-2.或者你也可以直接关闭内存池的错误异常处理, 那么当内存池无法正常分配足够内存时, 将会直接返回 `NULL`：
+2.或者你也可以直接关闭内存池的错误异常处理，那么当内存池无法正常分配足够内存时，将会直接返回 `NULL`：
 
 ```c
 #include "PainterEngine.h"
@@ -488,14 +489,14 @@ int main()
 {
     px_memorypool mp;
     px_void* myalloc;
-    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache));//创建内存池
-	MP_NoCatchError(&mp, PX_TRUE);//设置内存池不捕获错误
-    myalloc=MP_Malloc(&mp, 1024*1024);//在内存池中分配1024*1024字节,但内存池不捕获错误，所以会直接返回NULL
+    mp=PX_MemorypoolCreate(my_memory_cache, sizeof(my_memory_cache)); // 创建内存池
+	MP_NoCatchError(&mp, PX_TRUE); // 设置内存池不捕获错误
+    myalloc=MP_Malloc(&mp, 1024*1024); // 在内存池中分配1024*1024字节,但内存池不捕获错误，所以会直接返回NULL
     return 1;
 }
 ```
 
-在 PainterEngine 中, 有 2 个系统默认的内存池, 它们分别是 `mp` 和 `mp_static`, 你可以打开 `PainterEngine_Application.h` 文件, 在当中找到这两个内存池的定义, 但我们最需要关注的, 还是下面的代码:
+在 PainterEngine 中，有 2 个系统默认的内存池，它们分别是 `mp` 和 `mp_static`，你可以打开 `PainterEngine_Application.h` 文件，在当中找到这两个内存池的定义，但我们最需要关注的，还是下面的代码：
 
 ```c
 #define PX_APPLICATION_NAME "PainterEngine"
@@ -504,16 +505,16 @@ int main()
 #define PX_APPLICATION_MEMORYPOOL_SPACE_SIZE (1024*1024*16)
 ```
 
-这是这两个内存池的直接相关配置宏, 其中 `PX_APPLICATION_MEMORYPOOL_STATIC_SIZE` 表示 `mp_static` 内存池的内存分配大小, 而 `PX_APPLICATION_MEMORYPOOL_DYNAMIC_SIZE` 则是 `mp` 内存池的内存分配大小, `PX_APPLICATION_MEMORYPOOL_SPACE_SIZE` 则是系统其它资源。PainterEngine 程序运行开始, 就至少会占用这三个宏累加起来的内存, 之后的内存分配, 都围绕在这几个内存池中进行。如果你发现 PainterEngine 运行的内存不够了, 你可以自己手动拓展内存池的大小。当然, 如果你希望节约点内存, 你也可以手动将它们改小。
+这是这两个内存池的直接相关配置宏，其中 `PX_APPLICATION_MEMORYPOOL_STATIC_SIZE` 表示 `mp_static` 内存池的内存分配大小，而 `PX_APPLICATION_MEMORYPOOL_DYNAMIC_SIZE` 则是 `mp` 内存池的内存分配大小，`PX_APPLICATION_MEMORYPOOL_SPACE_SIZE` 则是系统其它资源。PainterEngine 程序运行开始，就至少会占用这三个宏累加起来的内存，之后的内存分配都围绕在这几个内存池中进行。如果你发现 PainterEngine 运行的内存不够了，你可以自己手动拓展内存池的大小。当然，如果你希望节约点内存，你也可以手动将它们改小。
 
 
 ## 7. 使用 PainterEngine 创建 GUI 按钮
 
-在本章节中, 我们将第一次接触 PainterEngine 的组件。现在, 我们将使用 PainterEngine 创建一个经典 GUI 组件——按钮。
+在本章节中，我们将第一次接触 PainterEngine 的组件。现在，我们将使用 PainterEngine 创建一个经典 GUI 组件——按钮。
 
-在 PainterEngine 中, 所有的组件都是由 `PX_Object` 结构体进行描述的, 创建组件返回的都是一个 `PX_Object *` 类型的指针。
+在 PainterEngine 中，所有的组件都是由 `PX_Object` 结构体进行描述的，创建组件返回的都是一个 `PX_Object *` 类型的指针。
 
-但在本章节中, 我们并不需要考虑的那么复杂, 我们只需要创建一个按钮出来即可。在 PainterEngine 中, 最常用的按钮是 `PX_Object_PushButton` 类型。
+但在本章节中，我们并不需要考虑的那么复杂，我们只需要创建一个按钮出来即可。在 PainterEngine 中，最常用的按钮是 `PX_Object_PushButton` 类型。
 
 ```c
 #include "PainterEngine.h"
@@ -528,9 +529,9 @@ int main()
 ```
 ![](assets/img/7.1.gif)
 
-现在, 我们来详细看看 `PX_Object_PushButtonCreate` 函数。其中, 第一个参数是一个内存池, 在之前我们说过 PainterEngine 有 2 个系统默认的内存池，其实这里填 `mp` 或者 `mp_static` 都是没有问题的, 但考虑到界面可能会变动设计对象分配与销毁, 所以我们还是选择 `mp` 内存池。
+现在，我们来详细看看 `PX_Object_PushButtonCreate` 函数。其中，第一个参数是一个内存池，在之前我们说过 PainterEngine 有 2 个系统默认的内存池，其实这里填 `mp` 或者 `mp_static` 都是没有问题的，但考虑到界面可能会变动设计对象分配与销毁，所以我们还是选择 `mp` 内存池。
 
-第二个参数 `root` 是 PainterEngine 的根对象, PainterEngine 对象管理机制我们将在之后讨论。在这里, 你只需要理解为, 这里填 `root` 的意思是 **_创建一个按钮对象作为根对象的子对象_**。这样按钮就能链接到系统对象树中, 进行事件响应和渲染。
+第二个参数 `root` 是 PainterEngine 的根对象，PainterEngine 对象管理机制我们将在之后讨论。在这里，你只需要理解为，这里填 `root` 的意思是 **_创建一个按钮对象作为根对象的子对象_**。这样按钮就能链接到系统对象树中，进行事件响应和渲染。
 
 然后是按钮的 x，y，width，height，也就是位置和宽度高度等信息。
 
@@ -538,29 +539,29 @@ int main()
 
 ## 8. PainterEngine 对象传递机制
 
-在上一个章节中，我们初略了解了根对象 `root`, 那么在本章节, 我们将学习一下 PainterEngine 的对象管理机制。
+在上一个章节中，我们初略了解了根对象 `root`，那么在本章节，我们将学习一下 PainterEngine 的对象管理机制。
 
-正如我们之前所说的，在 PainterEngine 中, 所有的组件都是由 `PX_Object` 结构体进行描述的, PainterEngine 的对象是以树的形式存在的:
+正如我们之前所说的，在 PainterEngine 中，所有的组件都是由 `PX_Object` 结构体进行描述的，PainterEngine 的对象是以树的形式存在的：
 
 ![](assets/img/8.1.png)
 
-每一个 `PX_Object` 都是这个树中的一个节点, 都可以有自己的子节点（可能多个）和自己的父节点（只能有一个）。同时, 每一个 `PX_Object` 都有以下四个基本功能函数：
+每一个 `PX_Object` 都是这个树中的一个节点，都可以有自己的子节点（可能多个）和自己的父节点（只能有一个）。同时，每一个 `PX_Object` 都有以下四个基本功能函数：
 
-`Create`：对象创建函数，或者说是对象初始化函数, 在 PainterEngine 中它一般是 `PX_Object_xxxxxCreate` 这种形式的, 其中 `xxxxx` 就是这个对象的名称, 比如上一章节的 `PushButton`, `Create` 函数一般是对象的一些初始化处理，并会将自己连接到对象树中。
+`Create`：对象创建函数，或者说是对象初始化函数，在 PainterEngine 中它一般是 `PX_Object_xxxxxCreate` 这种形式的，其中 `xxxxx` 就是这个对象的名称，比如上一章节的 `PushButton`，`Create` 函数一般是对象的一些初始化处理，并会将自己连接到对象树中。
 
-`Update`：对象的物理信息更新工作基本在这个函数中完成，一般会处理对象的一些物理信息, 比如位置大小速度等，常见于游戏设计中的物体，在 GUI 对象中则比较少见，其设计是与之后的 `Render` 也就是绘制函数进行区分, 因为在例如游戏服务端中, 对象并不需要进行绘制, 且绘制是非常消耗性能的。
+`Update`：对象的物理信息更新工作基本在这个函数中完成，一般会处理对象的一些物理信息，比如位置大小速度等，常见于游戏设计中的物体，在 GUI 对象中则比较少见，其设计是与之后的 `Render` 也就是绘制函数进行区分，因为在例如游戏服务端中，对象并不需要进行绘制，且绘制是非常消耗性能的。
 
-`Render`: 对象的绘制工作基本在这个函数中完成, 用于 `PX_Object` 的绘制功能, 将图像数据渲染到屏幕上, 当然有些情况下物理信息也会在这个函数中做, 是因为这个对象的物理信息并不会影响游戏的实际运行结果, 例如一些特效和粒子效果, 多数的 GUI 组件也几乎只用得到 `Render` 函数。
+`Render`：对象的绘制工作基本在这个函数中完成，用于 `PX_Object` 的绘制功能，将图像数据渲染到屏幕上，当然有些情况下物理信息也会在这个函数中做，是因为这个对象的物理信息并不会影响游戏的实际运行结果，例如一些特效和粒子效果，多数的 GUI 组件也几乎只用得到 `Render` 函数。
 
 `Free`：对象的释放工作基本在这个函数中完成，例如在 `Create` 中加载了纹理，或者申请了内存，在这个函数中应该被释放。
 
 以上 `Update`、`Render`、`Free` 函数具有传递的特性，也就是说：
 
-* 如果某个对象节点执行了 `Update`, 那么它的所有子对象也会执行 `Update`
-* 如果某个对象节点执行了 `Render`, 那么它的所有子对象也会执行 `Render`
-* 如果某个对象节点执行了 `Free`, 那么它的所有子对象也会执行 `Free`, 父对象被删除了, 它的子节点也会被删除, 并且将会一直迭代到以这个节点为根节点的所有子节点都被删除。
+* 如果某个对象节点执行了 `Update`，那么它的所有子对象也会执行 `Update`
+* 如果某个对象节点执行了 `Render`，那么它的所有子对象也会执行 `Render`
+* 如果某个对象节点执行了 `Free`，那么它的所有子对象也会执行 `Free`，父对象被删除了，它的子节点也会被删除，并且将会一直迭代到以这个节点为根节点的所有子节点都被删除。
 
-因此，在上一章节我们创建了按钮，并将它连接到了 `root` 节点, 那么我们是不需要自己再手动执行 `Update`、`Render`、`Free` 函数的(在 `PX_Object_PushButton.c` 中它们已经被写好了), 因为根节点 `root` 是被自动更新渲染和释放的, 我们只需要负责 `Create` 就可以了。
+因此，在上一章节我们创建了按钮，并将它连接到了 `root` 节点，那么我们是不需要自己再手动执行 `Update`、`Render`、`Free` 函数的（在 `PX_Object_PushButton.c` 中它们已经被写好了），因为根节点 `root` 是被自动更新渲染和释放的，我们只需要负责 `Create` 就可以了。
 
 当然，如果你希望删除这个对象的话，你只需要调用 `PX_ObjectDelayDelete` 或者 `PX_ObjectDelete` 就可以了：
 
@@ -572,12 +573,12 @@ int main()
     PainterEngine_Initialize(800, 480);
     PainterEngine_LoadFontModule("assets/font.ttf",PX_FONTMODULE_CODEPAGE_GBK,20);
     myButtonObject=PX_Object_PushButtonCreate(mp,root,300,200,200,80,"我是一个按钮", PainterEngine_GetFontModule());
-    PX_ObjectDelayDelete(myButtonObject);//删除对象
+    PX_ObjectDelayDelete(myButtonObject); // 删除对象
     return 1;
 }
 ```
 
-这两个函数的功能和参数都是一样的, 但是 `PX_ObjectDelayDelete` 会在更新和渲染完成后才执行删除, `PX_ObjectDelete` 则是立即删除，我建议使用 `PX_ObjectDelayDelete`，这样你就可以避免在某些情况下因为对象被立即删除了，而其它对象仍然引用了这个对象的数据，这会导致其访问失效内存。
+这两个函数的功能和参数都是一样的，但是 `PX_ObjectDelayDelete` 会在更新和渲染完成后才执行删除，`PX_ObjectDelete` 则是立即删除，我建议使用 `PX_ObjectDelayDelete`，这样你就可以避免在某些情况下因为对象被立即删除了，而其它对象仍然引用了这个对象的数据，这会导致其访问失效内存。
 
 ## 9. PainterEngine 消息机制
 
@@ -605,15 +606,15 @@ int main()
 
 ![](assets/img/9.1.gif)
 
-其中, `PX_OBJECT_EVENT_FUNCTION` 是一个宏, 因为事件响应函数是一个固定的格式, 因此非常建议你使用宏的方式来申明它, 它的定义原型如下:
+其中，`PX_OBJECT_EVENT_FUNCTION` 是一个宏，因为事件响应函数是一个固定的格式，因此非常建议你使用宏的方式来申明它，它的定义原型如下：
 
 ```c
 #define PX_OBJECT_EVENT_FUNCTION(name) px_void name(PX_Object *pObject,PX_Object_Event e,px_void * ptr)
 ```
 
-可以看到, 这个回调函数有 3 个参数, 第一个是响应时间的对象的指针, 因为是按钮点击被触发了, 所以这个指针指向的就是这个按钮对象；第二个参数是事件类型 `e`，它是触发的事件类型；最后一个参数则是用户传递来的指针，它在注册时间响应函数 `PX_ObjectRegisterEvent` 被调用时就被传递进来了。
+可以看到，这个回调函数有 3 个参数，第一个是响应时间的对象的指针，因为是按钮点击被触发了，所以这个指针指向的就是这个按钮对象；第二个参数是事件类型 `e`，它是触发的事件类型；最后一个参数则是用户传递来的指针，它在注册时间响应函数 `PX_ObjectRegisterEvent` 被调用时就被传递进来了。
 
-事件类型有以下几种:
+事件类型有以下几种：
 
 ```c
 #define PX_OBJECT_EVENT_ANY					0 //任意事件
@@ -627,7 +628,7 @@ int main()
 #define PX_OBJECT_EVENT_CURSORWHEEL         8 //鼠标滚轮
 #define PX_OBJECT_EVENT_CURSORCLICK			9 //鼠标左键点击
 #define PX_OBJECT_EVENT_CURSORDRAG			10 //鼠标拖拽
-#define PX_OBJECT_EVENT_STRING				11 //字符串事件(输入法输入)
+#define PX_OBJECT_EVENT_STRING				11 //字符串事件（输入法输入）
 #define PX_OBJECT_EVENT_EXECUTE				12 //执行事件,不同组件有不同的执行方式
 #define PX_OBJECT_EVENT_VALUECHANGED		13 //值改变事件,例如滑动条的值改变,或者文本框的值改变,或者列表框的选中项改变
 #define PX_OBJECT_EVENT_DRAGFILE			14 //拖拽文件
@@ -649,34 +650,34 @@ int main()
 #define PX_OBJECT_EVENT_DAMAGE				30 //伤害事件
 ```
 
-以上事件并非全部都是任何组件都会响应的, 例如在上面例子中的 `PX_OBJECT_EVENT_EXECUTE`, 它是按钮被单击时会被触发的事件, 或者是文本框中按下回车会触发的事件, 但有些例如滚动条和进度条, 并不会触发这个事件。也就是说有些事件是专属的。
+以上事件并非全部都是任何组件都会响应的，例如在上面例子中的 `PX_OBJECT_EVENT_EXECUTE`，它是按钮被单击时会被触发的事件，或者是文本框中按下回车会触发的事件，但有些例如滚动条和进度条，并不会触发这个事件。也就是说有些事件是专属的。
 
-但是类似于带有 `CURSOR` 或 `KEY` 的事件，是所有连接在 `root` 节点的组件都会收到的事件(但不一定响应)。需要注意的是, 类似于鼠标或触摸屏的 `CURSOR` 事件, 并非只有鼠标或触摸屏移动到组件所在位置与范围时才会触发, 只要有这类事件投递到 `root` 节点, 他就会逐层传递给它的所有子节点。如果你希望实现类似于按钮中的 "仅在鼠标点击到按钮时" 才触发, 你必须自行实现范围判断。
+但是类似于带有 `CURSOR` 或 `KEY` 的事件，是所有连接在 `root` 节点的组件都会收到的事件（但不一定响应）。需要注意的是，类似于鼠标或触摸屏的 `CURSOR` 事件，并非只有鼠标或触摸屏移动到组件所在位置与范围时才会触发，只要有这类事件投递到 `root` 节点，他就会逐层传递给它的所有子节点。如果你希望实现类似于按钮中的 "仅在鼠标点击到按钮时" 才触发，你必须自行实现范围判断。
 
 你可以使用
 
 ```c
-px_float PX_Object_Event_GetCursorX(PX_Object_Event e);//获取cursor事件的x坐标
-px_float PX_Object_Event_GetCursorY(PX_Object_Event e);//获取cursor事件的y坐标
-px_float PX_Object_Event_GetCursorZ(PX_Object_Event e);//获取cursor事件的z坐标,一般用于鼠标中键滚轮
+px_float PX_Object_Event_GetCursorX(PX_Object_Event e); // 获取cursor事件的x坐标
+px_float PX_Object_Event_GetCursorY(PX_Object_Event e); // 获取cursor事件的y坐标
+px_float PX_Object_Event_GetCursorZ(PX_Object_Event e); // 获取cursor事件的z坐标,一般用于鼠标中键滚轮
 ```
 
 来获取 `cursor` 事件中类似于 "鼠标现在在哪里" 的功能。
 
-让我们回到源代码 `OnButtonClick` 中做的很简单, 就是用 `PX_Object_PushButtonSetText` 改变了按钮文本的内容。
+让我们回到源代码 `OnButtonClick` 中做的很简单，就是用 `PX_Object_PushButtonSetText` 改变了按钮文本的内容。
 
-最后让我们来到 `PX_ObjectRegisterEvent` 函数，这个函数用于将事件与 C 语言函数绑定在一起，第一个参数是我们之前创建好的按钮组件的指针，第二个参数是我们想要绑定的事件类型，这里的 `PX_OBJECT_EVENT_EXECUTE` 就是按钮被点击时触发的, 第三个则是用户指针, 它会被传递到回调函数中, 如果你用不到, 你可以直接填 `PX_NULL`。
+最后让我们来到 `PX_ObjectRegisterEvent` 函数，这个函数用于将事件与 C 语言函数绑定在一起，第一个参数是我们之前创建好的按钮组件的指针，第二个参数是我们想要绑定的事件类型，这里的 `PX_OBJECT_EVENT_EXECUTE` 就是按钮被点击时触发的，第三个则是用户指针，它会被传递到回调函数中，如果你用不到，你可以直接填 `PX_NULL`。
 
 ## 10. 小例子，用 PainterEngine 实现一个电子相册
 
-现在，让我们用一个小例子来开启 PainterEngine 组件化开发的第一步。在本例程中, 我将使用按钮和图片框组件, 开发一个电子相册功能。本文中的美术资源, 你可以在 `documents/logo` 中找到。
+现在，让我们用一个小例子来开启 PainterEngine 组件化开发的第一步。在本例程中，我将使用按钮和图片框组件，开发一个电子相册功能。本文中的美术资源，你可以在 `documents/logo` 中找到。
 
 ```c
 #include "PainterEngine.h"
 
 PX_Object* Previous, * Next, * Image;
-px_texture my_texture[10];//存放图片的数组
-px_int index = 0;//当前图片的索引
+px_texture my_texture[10]; // 存放图片的数组
+px_int index = 0; // 当前图片的索引
 
 PX_OBJECT_EVENT_FUNCTION(OnButtonPreClick)
 {
@@ -685,7 +686,7 @@ PX_OBJECT_EVENT_FUNCTION(OnButtonPreClick)
 	{
 		index = 9;
 	}
-	PX_Object_ImageSetTexture(Image, &my_texture[index]);//设置图片
+	PX_Object_ImageSetTexture(Image, &my_texture[index]); // 设置图片
 }
 
 PX_OBJECT_EVENT_FUNCTION(OnButtonNextClick)
@@ -701,54 +702,54 @@ PX_OBJECT_EVENT_FUNCTION(OnButtonNextClick)
 int main()
 {
     px_int i;
-    PainterEngine_Initialize(512, 560);//初始化
+    PainterEngine_Initialize(512, 560); // 初始化
     for(i=0;i<10;i++)
 	{
         px_char path[256];
         PX_sprintf1(path,256, "assets/%1.png", PX_STRINGFORMAT_INT(i+1));
-		if(!PX_LoadTextureFromFile(mp_static, &my_texture[i],path))//加载图片
+		if(!PX_LoadTextureFromFile(mp_static, &my_texture[i],path)) // 加载图片
 		{
-            //加载失败
+            // 加载失败
             printf("加载失败");
 			return 0;
 		}
 	}
-    PainterEngine_LoadFontModule("assets/font.ttf", PX_FONTMODULE_CODEPAGE_GBK, 20);//加载字体
-    Image = PX_Object_ImageCreate(mp, root, 0, 0, 512, 512, 0);//创建图片对象
-    Previous= PX_Object_PushButtonCreate(mp, root, 0, 512, 256, 48, "上一张",PainterEngine_GetFontModule());//创建按钮对象
-    Next = PX_Object_PushButtonCreate(mp, root, 256, 512, 256, 48, "下一张", PainterEngine_GetFontModule());//创建按钮对象
-	PX_ObjectRegisterEvent(Previous, PX_OBJECT_EVENT_EXECUTE, OnButtonPreClick, PX_NULL);//注册按钮事件
-	PX_ObjectRegisterEvent(Next, PX_OBJECT_EVENT_EXECUTE, OnButtonNextClick, PX_NULL);//注册按钮事件
+    PainterEngine_LoadFontModule("assets/font.ttf", PX_FONTMODULE_CODEPAGE_GBK, 20); // 加载字体
+    Image = PX_Object_ImageCreate(mp, root, 0, 0, 512, 512, 0); // 创建图片对象
+    Previous= PX_Object_PushButtonCreate(mp, root, 0, 512, 256, 48, "上一张",PainterEngine_GetFontModule()); // 创建按钮对象
+    Next = PX_Object_PushButtonCreate(mp, root, 256, 512, 256, 48, "下一张", PainterEngine_GetFontModule()); // 创建按钮对象
+	PX_ObjectRegisterEvent(Previous, PX_OBJECT_EVENT_EXECUTE, OnButtonPreClick, PX_NULL); // 注册按钮事件
+	PX_ObjectRegisterEvent(Next, PX_OBJECT_EVENT_EXECUTE, OnButtonNextClick, PX_NULL); // 注册按钮事件
     return 1;
 }
 ```
 
-在上述代码中 `OnButtonPreClick` 和 `OnButtonNextClick` 分别是上一张和下一张按钮的回调函数, 我们使用 `PX_Object_ImageSetTexture` 函数, 对图片框进行切换。
+在上述代码中 `OnButtonPreClick` 和 `OnButtonNextClick` 分别是上一张和下一张按钮的回调函数，我们使用 `PX_Object_ImageSetTexture` 函数，对图片框进行切换。
 
-而在 `main` 函数中, 我们先加载了 ttf 字体, 然后用 `PX_Object_ImageCreate` 创建了一个图片组件, 之后我们创建了 2 个按钮, 并用 `PX_ObjectRegisterEvent` 绑定了事件回调函数。最后, 看看运行结果：
+而在 `main` 函数中，我们先加载了 ttf 字体，然后用 `PX_Object_ImageCreate` 创建了一个图片组件，之后我们创建了 2 个按钮，并用 `PX_ObjectRegisterEvent` 绑定了事件回调函数。最后，看看运行结果：
 
 ![](assets/img/10.1.gif)
 
 ## 11. 更多常用的 PainterEngine 组件
 
-你可以在 `PainterEngine/kernel` 的文件中, 找到 PainterEngine 的内置组件, 所有的组件名称都是以 `PX_Object_XXXXX` 开头的, 在这里, 我为你列举一些常用的组件及示范代码：
+你可以在 `PainterEngine/kernel` 的文件中，找到 PainterEngine 的内置组件，所有的组件名称都是以 `PX_Object_XXXXX` 开头的，在这里，我为你列举一些常用的组件及示范代码：
 
-* 文本框:
+* 文本框：
 
 ```c
 #include "PainterEngine.h"
 PX_OBJECT_EVENT_FUNCTION(PX_Object_EditOnTextChanged)
 {
-	//文本改变后后这里会被执行
+	// 文本改变后后这里会被执行
 }
 
 int main()
 {
 	PX_Object* pObject;
 	PainterEngine_Initialize(600, 400);
-	//创建文本框
+	// 创建文本框
 	pObject=PX_Object_EditCreate(mp,root,200,180,200,40,0);
-	//注册编辑框文本改变事件
+	// 注册编辑框文本改变事件
 	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_VALUECHANGED, PX_Object_EditOnTextChanged,PX_NULL);
 	return 0;
 }
@@ -766,21 +767,21 @@ PX_OBJECT_RENDER_FUNCTION(PX_Object_OnMyListItemRender)
 	px_float objx,objy,objWidth,objHeight;
 	PX_Object_ListItem *pItem=PX_Object_GetListItem(pObject);
 	PX_OBJECT_INHERIT_CODE(pObject,objx, objy, objWidth, objHeight);
-	//绘制出其文本
+	// 绘制出其文本
 	PX_FontModuleDrawText(psurface, 0, (px_int)objx + 3, (px_int)objy + 3, PX_ALIGN_LEFTTOP, (const px_char *)pItem->pdata, PX_COLOR_WHITE);
 }
 
 
 PX_OBJECT_LIST_ITEM_CREATE_FUNCTION(PX_Object_OnMyListItemCreate)
 {
-	//绑定ListItem的渲染函数
+	// 绑定ListItem的渲染函数
 	ItemObject->Func_ObjectRender[0]=PX_Object_OnMyListItemRender;
 	return PX_TRUE;
 }
 
 PX_OBJECT_EVENT_FUNCTION(PX_Object_ListOnSelectChanged)
 {
-	//当选中项改变时
+	// 当选中项改变时
 	return;
 }
 
@@ -789,7 +790,7 @@ int main()
 	PX_Object* pObject;
 	PainterEngine_Initialize(600, 400);
 
-	//创建list
+	// 创建list
 	pObject = PX_Object_ListCreate(mp,root,100,100,400,200,24,PX_Object_OnMyListItemCreate,0);
 	PX_Object_ListAdd(pObject, "Item1");
 	PX_Object_ListAdd(pObject, "Item2");
@@ -810,7 +811,7 @@ int main()
 
 PX_OBJECT_EVENT_FUNCTION(SliderChanged)
 {
-	//垂直滑动条值改变后执行这里的代码
+	// 垂直滑动条值改变后执行这里的代码
 	return;
 }
 
@@ -818,9 +819,9 @@ int main()
 {
 	PX_Object* pObject;
 	PainterEngine_Initialize(600, 400);
-	//水平滑动条
+	// 水平滑动条
 	PX_Object_SliderBarCreate(mp, root, 200, 50, 200,24,PX_OBJECT_SLIDERBAR_TYPE_HORIZONTAL,PX_OBJECT_SLIDERBAR_STYLE_BOX);
-	//垂直滑动条
+	// 垂直滑动条
 	pObject=PX_Object_SliderBarCreate(mp, root, 200, 100, 24, 200, PX_OBJECT_SLIDERBAR_TYPE_VERTICAL, PX_OBJECT_SLIDERBAR_STYLE_BOX);
 	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_VALUECHANGED, SliderChanged, 0);
 	return 0;
@@ -853,7 +854,7 @@ int main()
 ```c
 #include "PainterEngine.h"
 
-//必须是生存域内有效可访问的数据,这里定义为全局变量
+// 必须是生存域内有效可访问的数据,这里定义为全局变量
 px_double data_x[100];
 px_double data_y[100];
 
@@ -865,7 +866,7 @@ int main()
 	px_int i;
 	PainterEngine_Initialize(600, 600);
 	
-	//初始化一个测试数据
+	// 初始化一个测试数据
 	for (i = 0; i < 100; i++)
 	{
 		data_x[i] = i;
@@ -874,26 +875,26 @@ int main()
 	
 	pObject = PX_Object_OscilloscopeCreate(mp, root, 0, 0, 600, 600, 0);
 
-	//设置水平坐标最小值最大值
+	// 设置水平坐标最小值最大值
 	PX_Object_OscilloscopeSetHorizontalMin(pObject, 0);
 	PX_Object_OscilloscopeSetHorizontalMax(pObject, 100);
 
-	//设置垂直坐标(左边)最小值最大值0-100
+	// 设置垂直坐标（左边）最小值最大值0-100
 	PX_Object_OscilloscopeSetLeftVerticalMin(pObject, 0);
 	PX_Object_OscilloscopeSetLeftVerticalMax(pObject, 100);
 
-	//数据类型
-	data.Color=PX_COLOR(255,192,255,128);//数据颜色
+	// 数据类型
+	data.Color=PX_COLOR(255,192,255,128); // 数据颜色
 	data.ID = 0;
-	data.linewidth = 3;//数据线宽
-	data.Map = PX_OBJECT_OSCILLOSCOPE_OSCILLOSCOPEDATA_MAP_LEFT;//数据映射到左边垂直坐标
-	data.MapHorizontalArray = data_x;//数据水平坐标
-	data.MapVerticalArray = data_y;//数据垂直坐标
-	data.Size = 100;//数据大小
-	data.Visibled = PX_TRUE;//数据可见
-	data.Normalization = 1;//数据归一化系数为1
+	data.linewidth = 3; // 数据线宽
+	data.Map = PX_OBJECT_OSCILLOSCOPE_OSCILLOSCOPEDATA_MAP_LEFT; // 数据映射到左边垂直坐标
+	data.MapHorizontalArray = data_x; // 数据水平坐标
+	data.MapVerticalArray = data_y; // 数据垂直坐标
+	data.Size = 100; // 数据大小
+	data.Visibled = PX_TRUE; // 数据可见
+	data.Normalization = 1; // 数据归一化系数为1
 	
-	//添加数据
+	// 添加数据
 	PX_Object_OscilloscopeAddData(pObject, data);
 	return 0;
 }
@@ -901,7 +902,7 @@ int main()
 
 ![](assets/img/11.5.gif)
 
-因为实在太多了, 我无法为你列举所有的组件, 如果你希望知道某个组件的具体用法和某个组件到底是做什么的, 你可以访问 PainterEngine 的 [组件市场](https://market.painterengine.com/), 在那里你可以找到 PainterEngine 内置组件和三方组件的说明和示例代码。
+因为实在太多了，我无法为你列举所有的组件，如果你希望知道某个组件的具体用法和某个组件到底是做什么的，你可以访问 PainterEngine 的 [组件市场](https://market.painterengine.com/)，在那里你可以找到 PainterEngine 内置组件和三方组件的说明和示例代码。
 
 ![](assets/img/11.6.png)
 
@@ -909,11 +910,11 @@ int main()
 
 PainterEngine 鼓励组件式的开发架构。也就是说，不论是游戏还是 GUI 交互程序，甚至是程序功能，我们都可以用组件的形式去开发它。
 
-组件式开发有点类似于 C++中的 Class，每一个组件，都要实现自己的 `Create`、`Update`、`Render`、`Free` 函数。关于上面四个函数, 你可以参考 [前面的对象传递机制](#8painterengine-对象传递机制) 这一章节。
+组件式开发有点类似于 C++中的 Class，每一个组件，都要实现自己的 `Create`、`Update`、`Render`、`Free` 函数。关于上面四个函数，你可以参考 [前面的对象传递机制](#8painterengine-对象传递机制) 这一章节。
 
 为了演示这一点，让我们来实现一个“可控拖动旋转图片组件”，即我们可以用鼠标拖动图片在界面的位置，并用鼠标中键来旋转它。
 
-为了实现这一个功能, 让我们一步一步完成这个步骤。首先, 为了创建一个组件, 我们需要一个结构体来描述我们的组件。我们需要绘制图片, 所以我们需要一个 `px_texture` 类型。同时, 我们还需要旋转图片, 因此它还有一个 `rotation` 用于描述旋转的角度：
+为了实现这一个功能，让我们一步一步完成这个步骤。首先，为了创建一个组件，我们需要一个结构体来描述我们的组件。我们需要绘制图片，所以我们需要一个 `px_texture` 类型。同时，我们还需要旋转图片，因此它还有一个 `rotation` 用于描述旋转的角度：
 
 ```c
 #include "PainterEngine.h"
@@ -930,7 +931,7 @@ px_int main()
 }
 ```
 
-之后, 我们需要定义我们的 `Create`、`Update`、`Render` 和 `Free` 函数, 其中 `Update`、`Render`、`Free` 有对应的格式, 它们都有一个宏来简化我们的定义过程：
+之后，我们需要定义我们的 `Create`、`Update`、`Render` 和 `Free` 函数，其中 `Update`、`Render`、`Free` 有对应的格式，它们都有一个宏来简化我们的定义过程：
 
 ```c
 #define PX_OBJECT_RENDER_FUNCTION(name) px_void name(px_surface *psurface,PX_Object *pObject,px_int idesc,px_dword elapsed)
@@ -938,7 +939,7 @@ px_int main()
 #define PX_OBJECT_FREE_FUNCTION(name) px_void name(PX_Object *pObject,px_int idesc)
 ```
 
-那么, 在主函数中, 我们就可以这样定义我们的这几个函数：
+那么，在主函数中，我们就可以这样定义我们的这几个函数：
 
 ```c
 #include "PainterEngine.h"
@@ -971,7 +972,7 @@ px_int main()
 }
 ```
 
-其中, 因为我们不需要更新一些物理信息, 所以 `MyObjectUpdate` 函数中我们可以什么都不写, 在 `MyObjectRender` 中我们只需要把图片绘制出来就可以了, 这里我们先使用 `PX_ObjectGetDesc` 函数获得我们定义好的结构体指针, 它的第一个参数是结构体类型, 第二个参数则是函数传递进来的 `pObject` 指针, 然后我们只需要用 `PX_TextureRenderEx` 函数把图片绘制出来就可以了。
+其中，因为我们不需要更新一些物理信息，所以 `MyObjectUpdate` 函数中我们可以什么都不写，在 `MyObjectRender` 中我们只需要把图片绘制出来就可以了，这里我们先使用 `PX_ObjectGetDesc` 函数获得我们定义好的结构体指针，它的第一个参数是结构体类型，第二个参数则是函数传递进来的 `pObject` 指针，然后我们只需要用 `PX_TextureRenderEx` 函数把图片绘制出来就可以了。
 
 多提一句，`PX_TextureRenderEx` 函数用于在指定的表面上渲染纹理，并提供了对齐、混合、缩放和旋转等扩展选项。其中：
   * `psurface`：指向要渲染纹理的表面的指针。
@@ -983,26 +984,26 @@ px_int main()
   * `scale`：纹理的缩放因子（1.0 表示不缩放）。
   * `Angle`：纹理的旋转角度，以度为单位。
 
-最后, 是时候编写创建新对象的函数了, 这里我们需要用到 `PX_ObjectCreateEx` 函数, `PX_ObjectCreateEx` 函数用于创建一个扩展对象，并初始化其属性和回调函数。它的参数说明如下:
+最后，是时候编写创建新对象的函数了，这里我们需要用到 `PX_ObjectCreateEx` 函数，`PX_ObjectCreateEx` 函数用于创建一个扩展对象，并初始化其属性和回调函数。它的参数说明如下：
 
 * `mp`：指向内存池的指针，用于分配对象所需的内存。
 * `Parent`：指向父对象的指针，如果没有父对象则为 `NULL`。
 * `x`：对象在 x 轴上的初始位置。
 * `y`：对象在 y 轴上的初始位置。
-* `z`：对象在 z 轴上的初始位置, z 坐标会影响其渲染的先后顺序。
+* `z`：对象在 z 轴上的初始位置，z 坐标会影响其渲染的先后顺序。
 * `Width`：对象的宽度。
 * `Height`：对象的高度。
-* `Lenght`：对象的长度,2D 对象, 一般可以是 0。
+* `Lenght`：对象的长度，2D 对象，一般可以是 0。
 * `type`：对象的类型。
 * `Func_ObjectUpdate`：指向对象更新函数的指针。
 * `Func_ObjectRender`：指向对象渲染函数的指针。
 * `Func_ObjectFree`：指向对象释放函数的指针。
-* `desc`：指向对象描述数据的指针。你可以设置为 0, 创建时会把这个对象类型的数据填充为 0。
-* `size`：描述数据的大小, 就是你定义的对象结构体类型的大小，创建对象函数会在内存池申请一段内存空间，并用于存储你的对象结构体。
+* `desc`：指向对象描述数据的指针。你可以设置为 0，创建时会把这个对象类型的数据填充为 0。
+* `size`：描述数据的大小，就是你定义的对象结构体类型的大小，创建对象函数会在内存池申请一段内存空间，并用于存储你的对象结构体。
 
-在创建好一个空对象后, 我们使用 `PX_ObjectGetDescIndex` 将对象中的对象结构体指针取出来, 这是一个三参数的函数, 第一个参数是对象结构体类型, 第二个参数则是 `PX_Object *` 指针类型, 因为一个 `PX_Object` 可以将多个对象结构体组合在一起, 这个组合结构体我们将在之后的教程中会进一步描述, 但现在我们只需要知道, 调用 `PX_ObjectCreateEx` 函数后, 其第一个存储的对象结构体索引是 0 就可以了。
+在创建好一个空对象后，我们使用 `PX_ObjectGetDescIndex` 将对象中的对象结构体指针取出来，这是一个三参数的函数，第一个参数是对象结构体类型，第二个参数则是 `PX_Object *` 指针类型，因为一个 `PX_Object` 可以将多个对象结构体组合在一起，这个组合结构体我们将在之后的教程中会进一步描述，但现在我们只需要知道，调用 `PX_ObjectCreateEx` 函数后，其第一个存储的对象结构体索引是 0 就可以了。
 
-取出结构体指针后, 我们对其进行一系列初始化, 比如加载图片和初始化旋转角度, 最后在 `main` 函数中我们创建这个对象：
+取出结构体指针后，我们对其进行一系列初始化，比如加载图片和初始化旋转角度，最后在 `main` 函数中我们创建这个对象：
 
 ```c
 #include "PainterEngine.h"
@@ -1019,23 +1020,23 @@ PX_OBJECT_UPDATE_FUNCTION(MyObjectUpdate)
 PX_OBJECT_RENDER_FUNCTION(MyObjectRender)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDesc(PX_Object_MyObject,pObject);
-	PX_TextureRenderEx(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0,1, pMyObject->rotation);//渲染图片
+	PX_TextureRenderEx(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0,1, pMyObject->rotation); // 渲染图片
 }
 
 PX_OBJECT_FREE_FUNCTION(MyObjectFree)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDesc(PX_Object_MyObject,pObject);
-	PX_TextureFree(&pMyObject->image);//释放图片
+	PX_TextureFree(&pMyObject->image); // 释放图片
 }
 
 PX_Object* PX_Object_MyObjectCreate(px_memorypool* mp, PX_Object* parent, px_float x, px_float y)
 {
-	PX_Object *pObject=PX_ObjectCreateEx(mp,parent,x,y,0,128,128,0,0, MyObjectUpdate, MyObjectRender, MyObjectFree,0,sizeof(PX_Object_MyObject));//创建一个空的自定义对象
-	PX_Object_MyObject* pMyObject = PX_ObjectGetDescIndex(PX_Object_MyObject, pObject,0);//取得自定义对象数据
+	PX_Object *pObject=PX_ObjectCreateEx(mp,parent,x,y,0,128,128,0,0, MyObjectUpdate, MyObjectRender, MyObjectFree,0,sizeof(PX_Object_MyObject)); // 创建一个空的自定义对象
+	PX_Object_MyObject* pMyObject = PX_ObjectGetDescIndex(PX_Object_MyObject, pObject,0); // 取得自定义对象数据
 	pMyObject->rotation = 0;
-	if(!PX_LoadTextureFromFile(mp,&pMyObject->image, "assets/test.png"))//加载图片
+	if(!PX_LoadTextureFromFile(mp,&pMyObject->image, "assets/test.png")) // 加载图片
 	{
-		PX_ObjectDelete(pObject);//加载失败则删除对象
+		PX_ObjectDelete(pObject); // 加载失败则删除对象
 		return PX_NULL;
 	}
 	return pObject;
@@ -1044,16 +1045,16 @@ PX_Object* PX_Object_MyObjectCreate(px_memorypool* mp, PX_Object* parent, px_flo
 px_int main()
 {
 	PainterEngine_Initialize(800, 480);
-	PX_Object_MyObjectCreate(mp,root,400,240);//创建一个自定义对象
+	PX_Object_MyObjectCreate(mp,root,400,240); // 创建一个自定义对象
 	return PX_TRUE;
 }
 ```
 
-那么它的运行效果是这样的:
+那么它的运行效果是这样的：
 
 ![](assets/img/12.1.png)
 
-但现在还没有结束, 我们怎么让我们的组件, 响应鼠标中键实现旋转呢?还记得我们之前在 [PushButton](#8painterengine-对象传递机制) 中的对象传递机制么？现在, 我们也要让我们的组件响应鼠标中键的信息, 因此我们给它注册一个 `PX_OBJECT_EVENT_CURSORWHEEL` 事件的回调函数, 代码如下:
+但现在还没有结束，我们怎么让我们的组件，响应鼠标中键实现旋转呢？还记得我们之前在 [PushButton](#8painterengine-对象传递机制) 中的对象传递机制么？现在，我们也要让我们的组件响应鼠标中键的信息，因此我们给它注册一个 `PX_OBJECT_EVENT_CURSORWHEEL` 事件的回调函数，代码如下：
 
 ```c
 #include "PainterEngine.h"
@@ -1070,62 +1071,62 @@ PX_OBJECT_UPDATE_FUNCTION(MyObjectUpdate)
 PX_OBJECT_RENDER_FUNCTION(MyObjectRender)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDesc(PX_Object_MyObject,pObject);
-	PX_TextureRenderEx(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0,1, pMyObject->rotation);//渲染图片
+	PX_TextureRenderEx(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0,1, pMyObject->rotation); // 渲染图片
 }
 
 PX_OBJECT_FREE_FUNCTION(MyObjectFree)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDesc(PX_Object_MyObject,pObject);
-	PX_TextureFree(&pMyObject->image);//释放图片
+	PX_TextureFree(&pMyObject->image); // 释放图片
 }
 
 PX_OBJECT_EVENT_FUNCTION(MyObjectOnCursorWheel)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDescIndex(PX_Object_MyObject,pObject,0);
-	if(PX_ObjectIsCursorInRegion(pObject,e))//Object是鼠标位置是否选中当前组件，e是事件
+	if(PX_ObjectIsCursorInRegion(pObject,e)) // Object是鼠标位置是否选中当前组件，e是事件
 		pMyObject->rotation += (px_float)PX_Object_Event_GetCursorZ(e)/10;
 }
 
 PX_Object* PX_Object_MyObjectCreate(px_memorypool* mp, PX_Object* parent, px_float x, px_float y)
 {
-	PX_Object *pObject=PX_ObjectCreateEx(mp,parent,x,y,0,128,128,0,0, MyObjectUpdate, MyObjectRender, MyObjectFree,0,sizeof(PX_Object_MyObject));//创建一个空的自定义对象
-	PX_Object_MyObject* pMyObject = PX_ObjectGetDescIndex(PX_Object_MyObject, pObject,0);//取得自定义对象数据
+	PX_Object *pObject=PX_ObjectCreateEx(mp,parent,x,y,0,128,128,0,0, MyObjectUpdate, MyObjectRender, MyObjectFree,0,sizeof(PX_Object_MyObject)); // 创建一个空的自定义对象
+	PX_Object_MyObject* pMyObject = PX_ObjectGetDescIndex(PX_Object_MyObject, pObject,0); // 取得自定义对象数据
 	pMyObject->rotation = 0;
-	if(!PX_LoadTextureFromFile(mp,&pMyObject->image, "assets/test.png"))//加载图片
+	if(!PX_LoadTextureFromFile(mp,&pMyObject->image, "assets/test.png")) // 加载图片
 	{
-		PX_ObjectDelete(pObject);//加载失败则删除对象
+		PX_ObjectDelete(pObject); // 加载失败则删除对象
 		return PX_NULL;
 	}
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORWHEEL,MyObjectOnCursorWheel,0);//注册鼠标滚轮事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORWHEEL,MyObjectOnCursorWheel,0); // 注册鼠标滚轮事件
 	return pObject;
 }
 
 px_int main()
 {
 	PainterEngine_Initialize(800, 480);
-	PX_Object_MyObjectCreate(mp,root,400,240);//创建一个自定义对象
+	PX_Object_MyObjectCreate(mp,root,400,240); // 创建一个自定义对象
 	return PX_TRUE;
 }
 ```
 
-运行结果如下:
+运行结果如下：
 
 ![](assets/img/12.2.gif)
 
-如果你觉得旋转图的质量不好, 有很多锯齿, 这是因为 `PX_TextureRenderEx` 旋转时是对原图直接采样的。如果你想要高质量的旋转图, 你可以用 `PX_TextureRenderRotation` 函数来替换原函数:
+如果你觉得旋转图的质量不好，有很多锯齿，这是因为 `PX_TextureRenderEx` 旋转时是对原图直接采样的。如果你想要高质量的旋转图，你可以用 `PX_TextureRenderRotation` 函数来替换原函数：
 
 ```c
 PX_OBJECT_RENDER_FUNCTION(MyObjectRender)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDesc(PX_Object_MyObject,pObject);
-	PX_TextureRenderRotation(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0, pMyObject->rotation);//渲染图片
+	PX_TextureRenderRotation(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0, pMyObject->rotation); // 渲染图片
 }
 
 ```
 
 ![](assets/img/12.3.gif)
 
-那么, 我们如何实现拖动效果呢？想要做到拖动效果, 我们需要在对象结构体中, 新增 `float` 类型的变量 `x`, `y`, 用来记录当鼠标选中图片时的位置, 同时我们加入了 `bool` 类型的变量 `bselect`, 表示当前的图标是否被选中。当鼠标点击我们的图标以后, 我们就可以监听 `PX_OBJECT_EVENT_CURSORDRAG` 事件, 这是鼠标在屏幕上拖动时会产生的事件, 我们通过坐标的偏移, 移动我们的组件。最后, 不论鼠标非拖动时的移动或鼠标左键抬起, 都会取消我们组件的选中状态, 在对应处理函数中取消选中状态即可。
+那么，我们如何实现拖动效果呢？想要做到拖动效果，我们需要在对象结构体中，新增 `float` 类型的变量 `x`、`y`，用来记录当鼠标选中图片时的位置，同时我们加入了 `bool` 类型的变量 `bselect`，表示当前的图标是否被选中。当鼠标点击我们的图标以后，我们就可以监听 `PX_OBJECT_EVENT_CURSORDRAG` 事件，这是鼠标在屏幕上拖动时会产生的事件，我们通过坐标的偏移，移动我们的组件。最后，不论鼠标非拖动时的移动或鼠标左键抬起，都会取消我们组件的选中状态，在对应处理函数中取消选中状态即可。
 
 ```c
 #include "PainterEngine.h"
@@ -1144,26 +1145,26 @@ PX_OBJECT_UPDATE_FUNCTION(MyObjectUpdate)
 PX_OBJECT_RENDER_FUNCTION(MyObjectRender)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDesc(PX_Object_MyObject,pObject);
-	PX_TextureRenderRotation(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0, (px_int)pMyObject->rotation);//渲染图片
+	PX_TextureRenderRotation(psurface, &pMyObject->image, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER,0, (px_int)pMyObject->rotation); // 渲染图片
 }
 
 PX_OBJECT_FREE_FUNCTION(MyObjectFree)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDesc(PX_Object_MyObject,pObject);
-	PX_TextureFree(&pMyObject->image);//释放图片
+	PX_TextureFree(&pMyObject->image); // 释放图片
 }
 
 PX_OBJECT_EVENT_FUNCTION(MyObjectOnCursorWheel)
 {
 	PX_Object_MyObject *pMyObject=PX_ObjectGetDescIndex(PX_Object_MyObject,pObject,0);
-	if(PX_ObjectIsCursorInRegionAlign(pObject,e,PX_ALIGN_CENTER))//Object是鼠标位置是否选中当前组件，e是事件
+	if(PX_ObjectIsCursorInRegionAlign(pObject,e,PX_ALIGN_CENTER)) // Object是鼠标位置是否选中当前组件，e是事件
 		pMyObject->rotation += (px_float)PX_Object_Event_GetCursorZ(e)/10;
 }
 
 PX_OBJECT_EVENT_FUNCTION(MyObjectOnCursorDown)
 {
 	PX_Object_MyObject* pMyObject = PX_ObjectGetDescIndex(PX_Object_MyObject, pObject, 0);
-	if (PX_ObjectIsCursorInRegionAlign(pObject, e, PX_ALIGN_CENTER))//Object是鼠标位置是否选中当前组件，e是事件
+	if (PX_ObjectIsCursorInRegionAlign(pObject, e, PX_ALIGN_CENTER)) // Object是鼠标位置是否选中当前组件，e是事件
 	{
 		pMyObject->bselect = PX_TRUE;
 		pMyObject->last_cursorx = PX_Object_Event_GetCursorX(e);
@@ -1191,38 +1192,38 @@ PX_OBJECT_EVENT_FUNCTION(MyObjectOnCursorDrag)
 
 PX_Object* PX_Object_MyObjectCreate(px_memorypool* mp, PX_Object* parent, px_float x, px_float y)
 {
-	PX_Object *pObject=PX_ObjectCreateEx(mp,parent,x,y,0,128,128,0,0, MyObjectUpdate, MyObjectRender, MyObjectFree,0,sizeof(PX_Object_MyObject));//创建一个空的自定义对象
-	PX_Object_MyObject* pMyObject = PX_ObjectGetDescIndex(PX_Object_MyObject, pObject,0);//取得自定义对象数据
+	PX_Object *pObject=PX_ObjectCreateEx(mp,parent,x,y,0,128,128,0,0, MyObjectUpdate, MyObjectRender, MyObjectFree,0,sizeof(PX_Object_MyObject)); // 创建一个空的自定义对象
+	PX_Object_MyObject* pMyObject = PX_ObjectGetDescIndex(PX_Object_MyObject, pObject,0); // 取得自定义对象数据
 	pMyObject->rotation = 0;
-	if(!PX_LoadTextureFromFile(mp,&pMyObject->image, "assets/test.png"))//加载图片
+	if(!PX_LoadTextureFromFile(mp,&pMyObject->image, "assets/test.png")) // 加载图片
 	{
-		PX_ObjectDelete(pObject);//加载失败则删除对象
+		PX_ObjectDelete(pObject); // 加载失败则删除对象
 		return PX_NULL;
 	}
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORWHEEL,MyObjectOnCursorWheel,0);//注册鼠标滚轮事件
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDRAG,MyObjectOnCursorDrag,0);//注册鼠标拖拽事件
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDOWN,MyObjectOnCursorDown,0);//注册鼠标按下事件
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORUP,MyObjectOnCursorRelease,0);//注册鼠标释放事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORMOVE, MyObjectOnCursorRelease, 0);//注册鼠标释放事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORWHEEL,MyObjectOnCursorWheel,0); // 注册鼠标滚轮事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDRAG,MyObjectOnCursorDrag,0); // 注册鼠标拖拽事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDOWN,MyObjectOnCursorDown,0); // 注册鼠标按下事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORUP,MyObjectOnCursorRelease,0); // 注册鼠标释放事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORMOVE, MyObjectOnCursorRelease, 0); // 注册鼠标释放事件
 	return pObject;
 }
 
 px_int main()
 {
 	PainterEngine_Initialize(800, 480);
-	PX_Object_MyObjectCreate(mp,root,400,240);//创建一个自定义对象
+	PX_Object_MyObjectCreate(mp,root,400,240); // 创建一个自定义对象
 	return PX_TRUE;
 }
 ```
 ![](assets/img/12.4.gif)
 
-当然, 你可以调用 `PX_Object_MyObjectCreate` 多次, 创建多个组件对象, 它们的功能都是一样的：
+当然，你可以调用 `PX_Object_MyObjectCreate` 多次，创建多个组件对象，它们的功能都是一样的：
 
 ![](assets/img/12.5.gif)
 
 ## 13. 组合式组件设计
 
-PainterEngine 的组件允许同时拥有多种组件类型, 例如, 当我们将一个图片框组件和一个按钮进行组合, 我们就可以得到一个组合式组件图片按钮。
+PainterEngine 的组件允许同时拥有多种组件类型，例如，当我们将一个图片框组件和一个按钮进行组合，我们就可以得到一个组合式组件图片按钮。
 
 参考如下代码：
 
@@ -1233,8 +1234,8 @@ PX_Object* image;
 
 PX_OBJECT_EVENT_FUNCTION(ButtonEvent)
 {
-	PX_Object_Image *pImage=PX_Object_GetImage(pObject);//取得Image对象数据
-	PX_Object_Button *pButton=PX_Object_GetButton(pObject);//取得Button对象数据
+	PX_Object_Image *pImage=PX_Object_GetImage(pObject); // 取得Image对象数据
+	PX_Object_Button *pButton=PX_Object_GetButton(pObject); // 取得Button对象数据
 	if (pImage->pTexture==&tex1)
 	{
 		PX_Object_ImageSetTexture(pObject,&tex2);
@@ -1248,30 +1249,30 @@ PX_OBJECT_EVENT_FUNCTION(ButtonEvent)
 px_int main()
 {
 	PainterEngine_Initialize(800, 480);
-	if(!PX_LoadTextureFromFile(mp_static,&tex1,"assets/1.png")) return 0;//加载纹理1
-	if(!PX_LoadTextureFromFile(mp_static,&tex2,"assets/2.png")) return 0;//加载纹理2
-	image=PX_Object_ImageCreate(mp,root,300,140,200,200,&tex1);//创建Image对象
-	PX_Object_ButtonAttachObject(image, 1, PX_COLOR(64, 255, 255, 255), PX_COLOR(96, 255, 255, 255));//将一个Button对象类型组合到Image对象上
-	PX_ObjectRegisterEvent(image,PX_OBJECT_EVENT_EXECUTE,ButtonEvent,0);//这里实际上是注册Button对象的事件
+	if(!PX_LoadTextureFromFile(mp_static,&tex1,"assets/1.png")) return 0; // 加载纹理1
+	if(!PX_LoadTextureFromFile(mp_static,&tex2,"assets/2.png")) return 0; // 加载纹理2
+	image=PX_Object_ImageCreate(mp,root,300,140,200,200,&tex1); // 创建Image对象
+	PX_Object_ButtonAttachObject(image, 1, PX_COLOR(64, 255, 255, 255), PX_COLOR(96, 255, 255, 255)); // 将一个Button对象类型组合到Image对象上
+	PX_ObjectRegisterEvent(image,PX_OBJECT_EVENT_EXECUTE,ButtonEvent,0); // 这里实际上是注册Button对象的事件
 	return 1;
 }
 ```
 
-我们创建了一个 Image 图像框类型, 然后将一个 Button 对象类型组合上去, 这样我们就获得了一个图片按钮：
+我们创建了一个 Image 图像框类型，然后将一个 Button 对象类型组合上去，这样我们就获得了一个图片按钮：
 
 ![](assets/img/13.1.gif)
 
-那么, 我们如何设计我们自己的可组合对象呢？回到我们的第十二章节, 现在, 我们就将 "可拖拽" 这个功能设计成一个组合式组件。
+那么，我们如何设计我们自己的可组合对象呢？回到我们的第十二章节，现在，我们就将 "可拖拽" 这个功能设计成一个组合式组件。
 
-首先，仍然是定义一个组件对象结构体，为实现拖拽功能，我们需要鼠标按下时的 x, y 坐标, 同时需要一个 bool 类型记录是否是选中状态, 然后我们需要注册 `CURSOR` 事件, 这些事件在上一章节我们已经写过了, 最后, 我们用 `PX_ObjectCreateDesc` 函数创建一个对象结构体，并将它 Attach 到我们的对象上。
+首先，仍然是定义一个组件对象结构体，为实现拖拽功能，我们需要鼠标按下时的 x, y 坐标，同时需要一个 bool 类型记录是否是选中状态，然后我们需要注册 `CURSOR` 事件，这些事件在上一章节我们已经写过了，最后，我们用 `PX_ObjectCreateDesc` 函数创建一个对象结构体，并将它 Attach 到我们的对象上。
 
-`PX_ObjectCreateDesc` 是一个对象结构体创建函数, 它的定义原型如下：
+`PX_ObjectCreateDesc` 是一个对象结构体创建函数，它的定义原型如下：
 
 ```c
 px_void* PX_ObjectCreateDesc(PX_Object* pObject, px_int idesc, px_int type, Function_ObjectUpdate Func_ObjectUpdate, Function_ObjectRender Func_ObjectRender, Function_ObjectFree Func_ObjectFree, px_void* pDesc, px_int descSize)
 ```
 
-第一个参数是需要 Attach 的对象, 第二个参数是 Attach 到的对象索引。还记得我们之前提到的对象数据索引么, 使用 `PX_ObjectCreateEx` 默认使用的是索引 0, 因此, 如果我们要附加到一个对象上, 我们应该选 1, 当然如果 1 也被占用了, 它就是 2, 以此类推。第三个参数是对象类型, 我们使用 `PX_ObjectGetDescByType` 时, 可以通过对象类型取出对应的指针, 然后就是我们熟悉的 `Update`、`Render`、`Free` 三件套了, 最后一个参数给出其结构体描述和结构体大小。请参阅下面的代码:
+第一个参数是需要 Attach 的对象，第二个参数是 Attach 到的对象索引。还记得我们之前提到的对象数据索引么，使用 `PX_ObjectCreateEx` 默认使用的是索引 0，因此，如果我们要附加到一个对象上，我们应该选 1，当然如果 1 也被占用了，它就是 2，以此类推。第三个参数是对象类型，我们使用 `PX_ObjectGetDescByType` 时，可以通过对象类型取出对应的指针，然后就是我们熟悉的 `Update`、`Render`、`Free` 三件套了，最后一个参数给出其结构体描述和结构体大小。请参阅下面的代码：
 
 ```c
 #include "PainterEngine.h"
@@ -1335,21 +1336,21 @@ PX_Object* image;
 px_int main()
 {
 	PainterEngine_Initialize(800, 480);
-	if(!PX_LoadTextureFromFile(mp_static,&tex1,"assets/1.png")) return 0;//加载纹理1
-	image=PX_Object_ImageCreate(mp,root,300,140,200,200,&tex1);//创建Image对象
-	PX_Object_DragAttachObject(image, 1);//将一个Drag对象类型组合到Image对象上
+	if(!PX_LoadTextureFromFile(mp_static,&tex1,"assets/1.png")) return 0; // 加载纹理1
+	image=PX_Object_ImageCreate(mp,root,300,140,200,200,&tex1); // 创建Image对象
+	PX_Object_DragAttachObject(image, 1); // 将一个Drag对象类型组合到Image对象上
 	return 1;
 }
 ```
 
-运行结果如下:
+运行结果如下：
 
 ![](assets/img/13.2.gif)
 
 
 ## 14. 粒子系统
 
-PainterEngine 提供了一个粒子系统实现, 下面是一个粒子系统的示范程序：
+PainterEngine 提供了一个粒子系统实现，下面是一个粒子系统的示范程序：
 
 ```c
 #include "PainterEngine.h"
@@ -1372,7 +1373,7 @@ px_int main()
 
 ![](assets/img/14.1.gif)
 
-这是一个用组件包装起来的粒子系统实现, 另外一种是提供了更加详细的粒子系统参数配置:
+这是一个用组件包装起来的粒子系统实现，另外一种是提供了更加详细的粒子系统参数配置：
 
 ```c
 #include "PainterEngine.h"
@@ -1513,22 +1514,22 @@ PainterEngine 内置了对 wav 及 mp3 格式音乐的原生支持，使用 Pain
 ```c
 #include "PainterEngine.h"
 
-PX_SoundData sounddata;//定义音乐格式
+PX_SoundData sounddata; // 定义音乐格式
 int main()
 {
 	PX_Object* pObject;
 	PainterEngine_Initialize(600, 400);
-	PainterEngine_InitializeAudio();//初始化混音器及音乐设备
-	if (!PX_LoadSoundFromFile(mp_static, &sounddata, "assets/bliss.wav"))return PX_FALSE;//加载音乐,支持wav及mp3格式
-	PX_SoundPlayAdd(soundplay, PX_SoundCreate(&sounddata, PX_TRUE));//播放音乐
-	pObject = PX_Object_SoundViewCreate(mp,root,0,0,600,400,soundplay);//音乐频谱可视化组件,可选
+	PainterEngine_InitializeAudio(); // 初始化混音器及音乐设备
+	if (!PX_LoadSoundFromFile(mp_static, &sounddata, "assets/bliss.wav"))return PX_FALSE; // 加载音乐,支持wav及mp3格式
+	PX_SoundPlayAdd(soundplay, PX_SoundCreate(&sounddata, PX_TRUE)); // 播放音乐
+	pObject = PX_Object_SoundViewCreate(mp,root,0,0,600,400,soundplay); // 音乐频谱可视化组件,可选
 	return 0;
 }
 ```
 
 ![](assets/img/15.1.gif)
 
-其中, `PX_LoadSoundFromFile` 函数从文件中加载音乐, 并解码成 `sounddata` 类型。`PX_SoundCreate` 可以用 `sounddata` 创建一个播放实例, 第二个参数表示这个实例是否循环播放, 最后使用 `PX_SoundPlayAdd` 将播放实例送入混音器中, 即可完成音乐播放。
+其中，`PX_LoadSoundFromFile` 函数从文件中加载音乐，并解码成 `sounddata` 类型。`PX_SoundCreate` 可以用 `sounddata` 创建一个播放实例，第二个参数表示这个实例是否循环播放，最后使用 `PX_SoundPlayAdd` 将播放实例送入混音器中，即可完成音乐播放。
 
 ## 16. PainterEngine Live2D 动画系统
 
@@ -1550,12 +1551,12 @@ int main()
 	
 	PX_IO_Data iodata;
 	PainterEngine_Initialize(600, 600);
-	//加载模型数据
+	// 加载模型数据
 	iodata = PX_LoadFileToIOData("assets/release.live");
 	if (iodata.size == 0)return PX_FALSE;
 	PX_LiveFrameworkImport(mp_static, &liveframework, iodata.buffer, iodata.size);
 	PX_FreeIOData(&iodata);
-	//创建Live2D对象
+	// 创建Live2D对象
 	pObject = PX_Object_Live2DCreate(mp,root,300,300,&liveframework);
 	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, onClick, PX_NULL);
 
@@ -1572,13 +1573,13 @@ int main()
 PX_Object* PX_Object_Live2DCreate(px_memorypool* mp, PX_Object* Parent, px_int x, px_int y, PX_LiveFramework *pLiveFramework);
 ```
 
-- **描述**: 创建一个 Live2D 模型预览器对象，用于在图形界面中显示和交互 Live2D 模型。
-- **参数**:
-  - `mp`: 内存池指针，用于分配内存。
-  - `Parent`: 父对象，Live2D 模型预览器对象将作为其子对象。
-  - `x`, `y`: Live2D 模型预览器对象的位置坐标。
-  - `pLiveFramework`: Live2D 模型框架的指针，包括模型数据、纹理等信息。
-- **返回值**: 创建的 Live2D 模型预览器对象的指针。
+- **描述**：创建一个 Live2D 模型预览器对象，用于在图形界面中显示和交互 Live2D 模型。
+- **参数**：
+  - `mp`：内存池指针，用于分配内存。
+  - `Parent`：父对象，Live2D 模型预览器对象将作为其子对象。
+  - `x`, `y`：Live2D 模型预览器对象的位置坐标。
+  - `pLiveFramework`：Live2D 模型框架的指针，包括模型数据、纹理等信息。
+- **返回值**：创建的 Live2D 模型预览器对象的指针。
 
 `PX_Object_Live2DPlayAnimation`
 
@@ -1586,11 +1587,11 @@ PX_Object* PX_Object_Live2DCreate(px_memorypool* mp, PX_Object* Parent, px_int x
 px_void PX_Object_Live2DPlayAnimation(PX_Object *pObject, px_char *name);
 ```
 
-- **描述**: 播放指定名称的 Live2D 模型动画。
-- **参数**:
-  - `pObject`: Live2D 模型预览器对象的指针。
-  - `name`: 动画名称。
-- **返回值**: 无。
+- **描述**：播放指定名称的 Live2D 模型动画。
+- **参数**：
+  - `pObject`：Live2D 模型预览器对象的指针。
+  - `name`：动画名称。
+- **返回值**：无。
 
 `PX_Object_Live2DPlayAnimationRandom`
 
@@ -1598,10 +1599,10 @@ px_void PX_Object_Live2DPlayAnimation(PX_Object *pObject, px_char *name);
 px_void PX_Object_Live2DPlayAnimationRandom(PX_Object* pObject);
 ```
 
-- **描述**: 随机播放 Live2D 模型的动画。
-- **参数**:
-  - `pObject`: Live2D 模型预览器对象的指针。
-- **返回值**: 无。
+- **描述**：随机播放 Live2D 模型的动画。
+- **参数**：
+  - `pObject`：Live2D 模型预览器对象的指针。
+- **返回值**：无。
 
 `PX_Object_Live2DPlayAnimationIndex`
 
@@ -1609,11 +1610,11 @@ px_void PX_Object_Live2DPlayAnimationRandom(PX_Object* pObject);
 px_void PX_Object_Live2DPlayAnimationIndex(PX_Object* pObject, px_int index);
 ```
 
-- **描述**: 播放 Live2D 模型的指定索引处的动画。
-- **参数**:
-  - `pObject`: Live2D 模型预览器对象的指针。
-  - `index`: 动画的索引。
-- **返回值**: 无。
+- **描述**：播放 Live2D 模型的指定索引处的动画。
+- **参数**：
+  - `pObject`：Live2D 模型预览器对象的指针。
+  - `index`：动画的索引。
+- **返回值**：无。
 
 这些函数用于创建、配置和管理 Live2D 模型预览器对象，以在图形用户界面中显示和交互 Live2D 模型。可以使用这些函数播放 Live2D 模型的动画，包括指定名称、随机选择和指定索引处的动画。
 
@@ -1623,14 +1624,14 @@ px_void PX_Object_Live2DPlayAnimationIndex(PX_Object* pObject, px_int index);
 
 PainterEngine 内置了一个平台无关的脚本引擎系统，集成了编译，运行，调试等功能，你可以很轻松地在脚本之上，实现并行调度功能。PainterEngine Script 的设计，最大程度和 C 语言保持一致性，并对一些类型进行的拓展和简化。
 
-例如在脚本中，支持 `int`, `float`, `string`, `memory` 四种类型, `int` 类型是一个 32 位的有符号整数, `float` 是一个浮点数类型, 这个和 C 语言的类型保持了一致。`string` 类型类似于 C++的 `string`, 它允许直接用 `+` 法运算符进行字符串拼接, 使用 `strlen` 来获取其字符串长度, 而 `memory` 是一个二进制数据存储类型, 同样支持 `+` 运算进行拼接。
+例如在脚本中，支持 `int`、`float`、`string`、`memory` 四种类型，`int` 类型是一个 32 位的有符号整数，`float` 是一个浮点数类型，这个和 C 语言的类型保持了一致。`string` 类型类似于 C++的 `string`，它允许直接用 `+` 法运算符进行字符串拼接，使用 `strlen` 来获取其字符串长度，而 `memory` 是一个二进制数据存储类型，同样支持 `+` 运算进行拼接。
 
-在脚本中如果需要调用 C 语言函数，应该使用 `PX_VM_HOST_FUNCTION` 宏进行定义声明。和组件回调函数一样, `PX_VM_HOST_FUNCTION` 的定义如下:
+在脚本中如果需要调用 C 语言函数，应该使用 `PX_VM_HOST_FUNCTION` 宏进行定义声明。和组件回调函数一样，`PX_VM_HOST_FUNCTION` 的定义如下：
 
 ```c
 #define PX_VM_HOST_FUNCTION(name) px_bool name(PX_VM *Ins,px_void *userptr)
 ```
-在下面的内容中, 我将以一个简单的脚本实例作为范例, 为你演示如何使用 PainterEngine 的脚本引擎：
+在下面的内容中，我将以一个简单的脚本实例作为范例，为你演示如何使用 PainterEngine 的脚本引擎：
 
 ```c
 const px_char shellcode[] = "\
@@ -1670,15 +1671,15 @@ PX_VM_HOST_FUNCTION(host_sleep)
 
 ```
 
-首先, `shellcode` 数组中存储着一个输出九九乘法表的程序, 其中需要调用两个 `host` 函数(脚本调用 C 语言函数称为 host call, 因此 host 函数实际就是专门提供给脚本调用的 C 语言函数), 一个是 `print` 函数, 一个是 `sleep` 函数。因此在下面, 我们定义了两个 `host` 函数, `PX_VM_HOSTPARAM` 用于取得脚本传递过来的参数。在这里, 我们需要判断传递过来的参数类型是否符合我们的调用规则, 像 `host_print` 函数, 作用是在 PainterEngine 中输出字符串, 而 `sleep` 函数, 则是用来延迟一段时间。
+首先，`shellcode` 数组中存储着一个输出九九乘法表的程序，其中需要调用两个 `host` 函数（脚本调用 C 语言函数称为 host call，因此 host 函数实际就是专门提供给脚本调用的 C 语言函数），一个是 `print` 函数，一个是 `sleep` 函数。因此在下面，我们定义了两个 `host` 函数，`PX_VM_HOSTPARAM` 用于取得脚本传递过来的参数。在这里，我们需要判断传递过来的参数类型是否符合我们的调用规则，像 `host_print` 函数，作用是在 PainterEngine 中输出字符串，而 `sleep` 函数，则是用来延迟一段时间。
 
-现在，PainterEngine Script 是一个编译型脚本, 我们需要将上面的代码编译成二进制形式, 然后将它送入虚拟机中运行, 观察以下代码：
+现在，PainterEngine Script 是一个编译型脚本，我们需要将上面的代码编译成二进制形式，然后将它送入虚拟机中运行，观察以下代码：
 
 ```c
 PX_VM vm;
 PX_OBJECT_UPDATE_FUNCTION(VMUpdate)
 {
-	PX_VMRun(&vm, 0xffff, elapsed);//运行虚拟机
+	PX_VMRun(&vm, 0xffff, elapsed); // 运行虚拟机
 }
 
 px_int main()
@@ -1687,26 +1688,26 @@ px_int main()
 	px_memory bin;
 	PainterEngine_Initialize(800, 600);
 	PainterEngine_SetBackgroundColor(PX_COLOR_BLACK);
-	PX_CompilerInitialize(mp, &compiler);//初始化编译器
-	PX_CompilerAddSource(&compiler, shellcode);//编译器中添加代码
-	PX_MemoryInitialize(mp, &bin);//初始化内存/用于存储编译后的结果
+	PX_CompilerInitialize(mp, &compiler); // 初始化编译器
+	PX_CompilerAddSource(&compiler, shellcode); // 编译器中添加代码
+	PX_MemoryInitialize(mp, &bin); // 初始化内存/用于存储编译后的结果
 	if (!PX_CompilerCompile(&compiler, &bin, 0, "main"))
 	{
-		//编译失败
+		// 编译失败
 		return 0;
 	}
-	PX_CompilerFree(&compiler);//释放编译器
-	PX_VMInitialize(&vm,mp,bin.buffer,bin.usedsize);//初始化虚拟机
-	PX_VMRegisterHostFunction(&vm, "print", host_print,0);//注册主机函数print
-	PX_VMRegisterHostFunction(&vm, "sleep", host_sleep,0);//注册主机函数sleep
-	PX_VMBeginThreadFunction(&vm, 0, "main", PX_NULL, 0);//开始运行虚拟机函数
-	PX_ObjectSetUpdateFunction(root, VMUpdate, 0);//设置更新函数
+	PX_CompilerFree(&compiler); // 释放编译器
+	PX_VMInitialize(&vm,mp,bin.buffer,bin.usedsize); // 初始化虚拟机
+	PX_VMRegisterHostFunction(&vm, "print", host_print,0); // 注册主机函数print
+	PX_VMRegisterHostFunction(&vm, "sleep", host_sleep,0); // 注册主机函数sleep
+	PX_VMBeginThreadFunction(&vm, 0, "main", PX_NULL, 0); // 开始运行虚拟机函数
+	PX_ObjectSetUpdateFunction(root, VMUpdate, 0); // 设置更新函数
 
 	return 0;
 }
 ```
 
-首先我们用 `PX_Compiler` 编译我们的脚本, 然后我们注册我们的 host call, `PX_VMBeginThreadFunction` 的功能是 C 语言调用脚本语言中函数, 在这里我们调用脚本中的 `main` 开始运行我们的脚本函数, 最后我们将一个 `Update` 函数绑定到 root 节点, 以循环更新虚拟机, 来执行脚本。
+首先我们用 `PX_Compiler` 编译我们的脚本，然后我们注册我们的 host call，`PX_VMBeginThreadFunction` 的功能是 C 语言调用脚本语言中函数，在这里我们调用脚本中的 `main` 开始运行我们的脚本函数，最后我们将一个 `Update` 函数绑定到 root 节点，以循环更新虚拟机，来执行脚本。
 
 最后，看看运行的结果。
 
@@ -1722,19 +1723,19 @@ px_int main()
 	PainterEngine_Initialize(800, 480);
 	PX_VMDebuggerMapInitialize(mp,&debugmap);
 	PainterEngine_SetBackgroundColor(PX_COLOR_BLACK);
-	PX_CompilerInitialize(mp, &compiler);//初始化编译器
-	PX_CompilerAddSource(&compiler, shellcode);//编译器中添加代码
-	PX_MemoryInitialize(mp, &bin);//初始化内存/用于存储编译后的结果
+	PX_CompilerInitialize(mp, &compiler); // 初始化编译器
+	PX_CompilerAddSource(&compiler, shellcode); // 编译器中添加代码
+	PX_MemoryInitialize(mp, &bin); // 初始化内存/用于存储编译后的结果
 	if (!PX_CompilerCompile(&compiler, &bin, &debugmap, "main"))
 	{
-		//编译失败
+		// 编译失败
 		return 0;
 	}
-	PX_CompilerFree(&compiler);//释放编译器
-	PX_VMInitialize(&vm,mp,bin.buffer,bin.usedsize);//初始化虚拟机
-	PX_VMRegisterHostFunction(&vm, "print", host_print,0);//注册主机函数print
-	PX_VMRegisterHostFunction(&vm, "sleep", host_sleep,0);//注册主机函数sleep
-	PX_VMBeginThreadFunction(&vm, 0, "main", PX_NULL, 0);//开始运行虚拟机函数
+	PX_CompilerFree(&compiler); // 释放编译器
+	PX_VMInitialize(&vm,mp,bin.buffer,bin.usedsize); // 初始化虚拟机
+	PX_VMRegisterHostFunction(&vm, "print", host_print,0); // 注册主机函数print
+	PX_VMRegisterHostFunction(&vm, "sleep", host_sleep,0); // 注册主机函数sleep
+	PX_VMBeginThreadFunction(&vm, 0, "main", PX_NULL, 0); // 开始运行虚拟机函数
 	PX_Object *pDbgObject = PX_Object_AsmDebuggerCreate(mp, root, 0, 0, 800, 480, 0);
 	pDbgObject->Visible = PX_TRUE;
 	PX_Object_AsmDebuggerAttach(pDbgObject, &debugmap, &vm);
@@ -1746,15 +1747,15 @@ px_int main()
 
 ## 18. 使用 PainterEngine 快速创作一个小游戏
 
-为了更好地演示 PainterEngine 的使用, 我将用 PainterEngine 创作一个简单的小游戏, 你可以在 documents/demo/game 下找到有关这个游戏的所有源码及原始素材。得益于 PainterEngine 的全平台可移植性，你也可以在 [PainterEngine 在线应用 APP--打地鼠](https://www.painterengine.com/main/app/documentgame/) 中, 直接玩到这个在线小游戏。
+为了更好地演示 PainterEngine 的使用，我将用 PainterEngine 创作一个简单的小游戏，你可以在 documents/demo/game 下找到有关这个游戏的所有源码及原始素材。得益于 PainterEngine 的全平台可移植性，你也可以在 [PainterEngine 在线应用 APP——打地鼠](https://www.painterengine.com/main/app/documentgame/) 中，直接玩到这个在线小游戏。
 
 在这个小游戏中，我将充分为你展示，如何使用 PainterEngine 的组件化开发模式，快速创建一个 App Game。
 
-让我们先开始游戏创作的第一步，我们先准备好所需的美术资源及素材:
+让我们先开始游戏创作的第一步，我们先准备好所需的美术资源及素材：
 
 ![](assets/img/18.1.png)
 
-这是一个简单的游戏背景素材，然后我们就可以开始创建我们的 `main.c` 源代码文件, 在 PainterEngine 中我们输入下面的代码：
+这是一个简单的游戏背景素材，然后我们就可以开始创建我们的 `main.c` 源代码文件，在 PainterEngine 中我们输入下面的代码：
 
 ```c
 px_int main()
@@ -1786,23 +1787,23 @@ px_int main()
 }
 ```
 
-在代码的开始阶段, 我们初始化了一个 800x480 的窗口, 然后我们初始化了字模, 并用 `PX_FontModuleSetCodepage` 函数设置了其为 GBK 字符集, 再后面, 我们就是把资源加载进 PainterEngine 的资源管理器中了。
+在代码的开始阶段，我们初始化了一个 800x480 的窗口，然后我们初始化了字模，并用 `PX_FontModuleSetCodepage` 函数设置了其为 GBK 字符集，再后面，我们就是把资源加载进 PainterEngine 的资源管理器中了。
 
 ### 加载资源及设置背景
 
-PainterEngine 内置了一个资源管理器，它在 `PainterEngine_Initialize` 中就被初始化了, 使用的是 `mp_static` 内存池。资源管理器的作用是像数据库一样, 将图片、音频、脚本等等素材加载到内存中, 并将它映射为一个 `key`, 之后对资源的访问都是通过 `key` 进行的。资源管理器的映射做了专门的优化, 因此你不必太担心映射查询带来的性能损耗问题。
+PainterEngine 内置了一个资源管理器，它在 `PainterEngine_Initialize` 中就被初始化了，使用的是 `mp_static` 内存池。资源管理器的作用是像数据库一样，将图片、音频、脚本等等素材加载到内存中，并将它映射为一个 `key`，之后对资源的访问都是通过 `key` 进行的。资源管理器的映射做了专门的优化，因此你不必太担心映射查询带来的性能损耗问题。
 
-`PX_LoadTextureToResource` 函数用于将一个文件系统的资源加载到资源管理器中, 第一个参数是这个资源管理器的实例指针, PainterEngine 在初始化阶段会默认创建一个这样的管理器实例, 因此你可以直接用 `PainterEngine_GetResourceLibrary` 获得它。第二个参数是需要加载文件的所在路径，第三个参数则是我们想映射的 `key` 了。
+`PX_LoadTextureToResource` 函数用于将一个文件系统的资源加载到资源管理器中，第一个参数是这个资源管理器的实例指针，PainterEngine 在初始化阶段会默认创建一个这样的管理器实例，因此你可以直接用 `PainterEngine_GetResourceLibrary` 获得它。第二个参数是需要加载文件的所在路径，第三个参数则是我们想映射的 `key` 了。
 
-在代码的下一步, 我们使用 `PX_LoadTextureToResource` 加载了若干图片, `PX_LoadAnimationToResource` 加载了一个 2dx 动画(请到应用市场查看 2DX 动画详细说明)。最后，在游戏里我们并没有使用 TTF 字模文件，我们循环加载了 `0.png` 到 `9.png`, 并将这些纹理作为图片插入到字模中, 这样这个字模绘制数字时, 实际显示的就是我们的图片。
+在代码的下一步，我们使用 `PX_LoadTextureToResource` 加载了若干图片，`PX_LoadAnimationToResource` 加载了一个 2dx 动画（请到应用市场查看 2DX 动画详细说明）。最后，在游戏里我们并没有使用 TTF 字模文件，我们循环加载了 `0.png` 到 `9.png`，并将这些纹理作为图片插入到字模中，这样这个字模绘制数字时，实际显示的就是我们的图片。
 
-同时我们还调用了 `PainterEngine_SetBackgroundTexture` 设置 PainterEngine 界面的背景, 请注意 `PX_ResourceLibraryGetTexture` 函数, 它的作用是使用一个查询 `key`, 从资源管理器中取得这个图片的数据结构指针。以上完成后你将可以看到这样的界面：
+同时我们还调用了 `PainterEngine_SetBackgroundTexture` 设置 PainterEngine 界面的背景，请注意 `PX_ResourceLibraryGetTexture` 函数，它的作用是使用一个查询 `key`，从资源管理器中取得这个图片的数据结构指针。以上完成后你将可以看到这样的界面：
 
 ![](assets/img/18.2.png)
 
 ### 设计游戏对象
 
-我们先来设计第一个游戏对象，就是 `开始游戏按钮`。这一部分我们并不要写太多的代码, 因为 PainterEngine 内置就有这种按钮的功能：
+我们先来设计第一个游戏对象，就是 `开始游戏按钮`。这一部分我们并不要写太多的代码，因为 PainterEngine 内置就有这种按钮的功能：
 
 ```c
 startgame = PX_Object_PushButtonCreate(mp, root, 300, 200, 200, 90, "Start Game", 0);
@@ -1812,33 +1813,33 @@ PX_Object_PushButtonSetPushColor(startgame, PX_COLOR(224, 255, 255, 255));
 PX_Object_PushButtonSetCursorColor(startgame, PX_COLOR(168, 255, 255, 255));
 ```
 
-我们使用了一系列函数, 改变了按钮的背景颜色、鼠标悬停颜色和鼠标按下的颜色, 因此你可以看到这样的情况：
+我们使用了一系列函数，改变了按钮的背景颜色、鼠标悬停颜色和鼠标按下的颜色，因此你可以看到这样的情况：
 
 ![](assets/img/18.3.png)
 
-然后我们需要创建我们的游戏里的地鼠对象, 这是游戏里最复杂的对象, 我贴上详细代码, 以逐步解释它们：
+然后我们需要创建我们的游戏里的地鼠对象，这是游戏里最复杂的对象，我贴上详细代码，以逐步解释它们：
 
 ```c
 typedef enum
 {
-	PX_OBJECT_FOX_STATE_IDLE,//狐狸还在洞里
-	PX_OBJECT_FOX_STATE_RASING,//狐狸正在升起
-	PX_OBJECT_FOX_STATE_TAUNT,//狐狸在嘲讽
-	PX_OBJECT_FOX_STATE_ESCAPE,//狐狸逃跑
-	PX_OBJECT_FOX_STATE_BEAT,//狐狸被打
-	PX_OBJECT_FOX_STATE_HURT,//狐狸受伤后逃跑
+	PX_OBJECT_FOX_STATE_IDLE,   // 狐狸还在洞里
+	PX_OBJECT_FOX_STATE_RASING, // 狐狸正在升起
+	PX_OBJECT_FOX_STATE_TAUNT,  // 狐狸在嘲讽
+	PX_OBJECT_FOX_STATE_ESCAPE, // 狐狸逃跑
+	PX_OBJECT_FOX_STATE_BEAT,   // 狐狸被打
+	PX_OBJECT_FOX_STATE_HURT,   // 狐狸受伤后逃跑
 }PX_OBJECT_FOX_STATE;
 
 typedef struct
 {
-	PX_OBJECT_FOX_STATE state;//狐狸状态
-	px_dword elapsed;//状态持续时间
-	px_float texture_render_offset;//纹理渲染偏移
-	px_dword gen_rand_time;//生成随机时间
-	px_float rasing_down_speed;//升起速度
-	px_texture render_target;//渲染目标
-	px_texture* pcurrent_display_texture;//当前显示的纹理
-	px_texture* ptexture_mask;//遮罩
+	PX_OBJECT_FOX_STATE state;            // 狐狸状态
+	px_dword elapsed;                     // 状态持续时间
+	px_float texture_render_offset;       // 纹理渲染偏移
+	px_dword gen_rand_time;               // 生成随机时间
+	px_float rasing_down_speed;           // 升起速度
+	px_texture render_target;             // 渲染目标
+	px_texture* pcurrent_display_texture; // 当前显示的纹理
+	px_texture* ptexture_mask;            // 遮罩
 }PX_Object_Fox;
 
 PX_OBJECT_UPDATE_FUNCTION(PX_Object_FoxOnUpdate)
@@ -1850,18 +1851,18 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_FoxOnUpdate)
 		{
 			if (pfox->gen_rand_time ==0)
 			{
-				pfox->gen_rand_time = PX_rand() % 3000 + 1000;//狐狸在洞里的时间,时间到了就升起来
+				pfox->gen_rand_time = PX_rand() % 3000 + 1000; // 狐狸在洞里的时间,时间到了就升起来
 			}
 			else
 			{
-				if (pfox->gen_rand_time <elapsed)//时间到了
+				if (pfox->gen_rand_time <elapsed) // 时间到了
 				{
-					//升起
+					// 升起
 					pfox->state = PX_OBJECT_FOX_STATE_RASING;
 					pfox->elapsed = 0;
 					pfox->gen_rand_time = 0;
 					pfox->texture_render_offset = pObject->Height;
-					//改变纹理
+					// 改变纹理
 					pfox->pcurrent_display_texture= PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_rasing");
 				}
 				else
@@ -1871,42 +1872,42 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_FoxOnUpdate)
 			}
 		}
 		break;
-		case PX_OBJECT_FOX_STATE_RASING://狐狸升起
+		case PX_OBJECT_FOX_STATE_RASING: // 狐狸升起
 		{
 			pfox->elapsed += elapsed;
-			//升起纹理偏移量
+			// 升起纹理偏移量
 			pfox->texture_render_offset -= pfox->rasing_down_speed * elapsed / 1000;
 			if (pfox->texture_render_offset <= 0)
 			{
 				pfox->texture_render_offset = 0;
-				pfox->state = PX_OBJECT_FOX_STATE_TAUNT;//升起后嘲讽
+				pfox->state = PX_OBJECT_FOX_STATE_TAUNT; // 升起后嘲讽
 				pfox->elapsed = 0;
 			}
 		}
 		break;
-		case PX_OBJECT_FOX_STATE_TAUNT://狐狸嘲讽
+		case PX_OBJECT_FOX_STATE_TAUNT: // 狐狸嘲讽
 		{
 			pfox->elapsed += elapsed;
-			if (pfox->elapsed>600&& pfox->elapsed <1500)//嘲讽时间
+			if (pfox->elapsed>600&& pfox->elapsed <1500) // 嘲讽时间
 			{
-				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_taunt");//嘲讽纹理
+				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_taunt"); // 嘲讽纹理
 			}
-			else if (pfox->elapsed>1500)//嘲讽结束
+			else if (pfox->elapsed>1500) // 嘲讽结束
 			{
 				pfox->texture_render_offset = 0;
-				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE;//逃跑
-				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_escape");//逃跑纹理
+				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE; // 逃跑
+				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_escape"); // 逃跑纹理
 				pfox->elapsed = 0;
 			}
 		}
 		break;
-		case PX_OBJECT_FOX_STATE_BEAT://狐狸被打
+		case PX_OBJECT_FOX_STATE_BEAT: // 狐狸被打
 		{
 			pfox->elapsed += elapsed;
 			if (pfox->elapsed>800)
 			{
-				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_hurt");//受伤纹理
-				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE;//逃跑
+				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_hurt"); // 受伤纹理
+				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE; // 逃跑
 			}
 		}
 		break;
@@ -1917,8 +1918,8 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_FoxOnUpdate)
 			if (pfox->texture_render_offset >= pObject->Height)
 			{
 				pfox->texture_render_offset = pObject->Height;
-				pfox->state = PX_OBJECT_FOX_STATE_IDLE;//逃跑结束
-				pfox->elapsed = 0;//重置时间
+				pfox->state = PX_OBJECT_FOX_STATE_IDLE; // 逃跑结束
+				pfox->elapsed = 0; // 重置时间
 				pfox->pcurrent_display_texture = PX_NULL;
 			}
 		}
@@ -1933,12 +1934,12 @@ PX_OBJECT_RENDER_FUNCTION(PX_Object_FoxOnRender)
 	PX_Object_Fox* pfox = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_FOX);
 	px_float x,y,width,height;
 	PX_OBJECT_INHERIT_CODE(pObject,x,y,width,height);
-	PX_TextureClearAll(&pfox->render_target, PX_COLOR_NONE);//清空渲染目标
+	PX_TextureClearAll(&pfox->render_target, PX_COLOR_NONE); // 清空渲染目标
 	if (pfox->pcurrent_display_texture)
 	{
-		PX_TextureRender(&pfox->render_target, pfox->pcurrent_display_texture, (px_int)pfox->render_target.width/2, (px_int)pfox->texture_render_offset, PX_ALIGN_MIDTOP, PX_NULL);//渲染狐狸
+		PX_TextureRender(&pfox->render_target, pfox->pcurrent_display_texture, (px_int)pfox->render_target.width/2, (px_int)pfox->texture_render_offset, PX_ALIGN_MIDTOP, PX_NULL); // 渲染狐狸
 	}
-	PX_TextureRenderMask(psurface, pfox->ptexture_mask, &pfox->render_target, (px_int)x, (px_int)y, PX_ALIGN_MIDBOTTOM, PX_NULL);//以遮罩形式绘制纹理
+	PX_TextureRenderMask(psurface, pfox->ptexture_mask, &pfox->render_target, (px_int)x, (px_int)y, PX_ALIGN_MIDBOTTOM, PX_NULL); // 以遮罩形式绘制纹理
 }
 
 
@@ -1948,12 +1949,12 @@ PX_OBJECT_FREE_FUNCTION(PX_Object_FoxFree)
 	PX_TextureFree(&pfox->render_target);
 }
 
-PX_OBJECT_EVENT_FUNCTION(PX_Object_FoxOnClick)//狐狸被点击
+PX_OBJECT_EVENT_FUNCTION(PX_Object_FoxOnClick) // 狐狸被点击
 {
 	PX_Object_Fox* pfox = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_FOX);
-	if (pfox->state == PX_OBJECT_FOX_STATE_TAUNT|| pfox->state == PX_OBJECT_FOX_STATE_RASING)//狐狸嘲讽或者升起时点击有效
+	if (pfox->state == PX_OBJECT_FOX_STATE_TAUNT|| pfox->state == PX_OBJECT_FOX_STATE_RASING) // 狐狸嘲讽或者升起时点击有效
 	{
-		if (PX_ObjectIsCursorInRegionAlign(pObject, e, PX_ALIGN_MIDBOTTOM))//点击有效区域
+		if (PX_ObjectIsCursorInRegionAlign(pObject, e, PX_ALIGN_MIDBOTTOM)) // 点击有效区域
 		{
 			px_int x= (px_int)PX_Object_Event_GetCursorX(e);
 			px_int y= (px_int)PX_Object_Event_GetCursorY(e);
@@ -1985,57 +1986,57 @@ PX_OBJECT_EVENT_FUNCTION(PX_Object_FoxOnReset)
 PX_Object *PX_Object_FoxCreate(px_memorypool *mp,PX_Object *parent,px_float x,px_float y)
 {
 	PX_Object_Fox* pfox;
-	px_texture *ptexture=PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(),"fox_rasing");//从资源管理器中获取纹理
+	px_texture *ptexture=PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(),"fox_rasing"); // 从资源管理器中获取纹理
 	PX_Object* pObject = PX_ObjectCreateEx(mp, parent, x, y, 0, ptexture->width*1.f, ptexture->height*1.f, 0, PX_OBJECT_TYPE_FOX, PX_Object_FoxOnUpdate, PX_Object_FoxOnRender, PX_Object_FoxFree, 0, sizeof(PX_Object_Fox));
 	pfox=PX_ObjectGetDescByType(pObject,PX_OBJECT_TYPE_FOX);
-	pfox->state= PX_OBJECT_FOX_STATE_IDLE;//狐狸状态
-	pfox->rasing_down_speed = 512;//升起速度
-	pfox->ptexture_mask = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_mask");//遮罩
+	pfox->state= PX_OBJECT_FOX_STATE_IDLE; // 狐狸状态
+	pfox->rasing_down_speed = 512; // 升起速度
+	pfox->ptexture_mask = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_mask"); // 遮罩
 	if(!PX_TextureCreate(mp,&pfox->render_target,ptexture->width,ptexture->height))
 	{
 		PX_ObjectDelete(pObject);
 		return 0;
 	}
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDOWN,PX_Object_FoxOnClick,0);//注册点击事件
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_RESET,PX_Object_FoxOnReset,0);//注册重置事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDOWN,PX_Object_FoxOnClick,0); // 注册点击事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_RESET,PX_Object_FoxOnReset,0); // 注册重置事件
 	return pObject;
 }
 
 ```
 
-* 首先是 `PX_Object_FoxOnUpdate`, 这是对象三件套中的 `update` 函数, 在这个函数中, 我们判断当前这个 `地鼠` 的状态, 到底是升起、嘲讽, 还是缩回去。
-* 然后是 `PX_Object_FoxOnRender`, 这是执行 `render` 的函数, 我们通过偏移量把纹理绘制出来, 当然在这里我们调用了 `PX_TextureRenderMask` 函数, 这是一个带纹理遮罩的绘制函数。
-* `PX_Object_FoxFree` 函数中, 主要是对临时渲染表面的释放处理, 虽然在本项目中并没有用到。
-* `PX_Object_FoxOnClick` 函数, 表示当前的地鼠被击打了, 其中是一些命中范围的判断, 如果被击中了, 应该把状态设置为受伤。
-* `PX_Object_FoxOnReset` 用于执行复位, 即游戏结束后, 所有地鼠都应该是重置状态, 这是一个 `PX_OBJECT_EVENT_RESET` 的回调, 你可以在 `PX_Object_FoxCreate` 中找到它。
-* 最后是 `PX_Object_FoxCreate` 函数, 在这个函数中我们做了一些初始化工作, 为 `地鼠` 注册了事件回调, 最终完成这个组件的开发设计。
+* 首先是 `PX_Object_FoxOnUpdate`，这是对象三件套中的 `update` 函数，在这个函数中，我们判断当前这个 `地鼠` 的状态，到底是升起、嘲讽，还是缩回去。
+* 然后是 `PX_Object_FoxOnRender`，这是执行 `render` 的函数，我们通过偏移量把纹理绘制出来，当然在这里我们调用了 `PX_TextureRenderMask` 函数，这是一个带纹理遮罩的绘制函数。
+* `PX_Object_FoxFree` 函数中，主要是对临时渲染表面的释放处理，虽然在本项目中并没有用到。
+* `PX_Object_FoxOnClick` 函数，表示当前的地鼠被击打了，其中是一些命中范围的判断，如果被击中了，应该把状态设置为受伤。
+* `PX_Object_FoxOnReset` 用于执行复位，即游戏结束后，所有地鼠都应该是重置状态，这是一个 `PX_OBJECT_EVENT_RESET` 的回调，你可以在 `PX_Object_FoxCreate` 中找到它。
+* 最后是 `PX_Object_FoxCreate` 函数，在这个函数中我们做了一些初始化工作，为 `地鼠` 注册了事件回调，最终完成这个组件的开发设计。
 
 
 ![](assets/img/18.4.gif)
 
 
-然后，我们需要创建一个 `锤子` 对象来改变我们鼠标的样式。锤子对象的设计很简单, 它只有 2 个纹理, 一个是鼠标没有按下时的状态，一个是按下时的状态。不同的状态对应不同的纹理：
+然后，我们需要创建一个 `锤子` 对象来改变我们鼠标的样式。锤子对象的设计很简单，它只有 2 个纹理，一个是鼠标没有按下时的状态，一个是按下时的状态。不同的状态对应不同的纹理：
 
 ```c
 typedef struct
 {
-	px_texture ham01;//锤子纹理1,没有按下
-	px_texture ham02;//锤子纹理2,按下
-	px_bool bHit;//是否按下
+	px_texture ham01; // 锤子纹理1,没有按下
+	px_texture ham02; // 锤子纹理2,按下
+	px_bool bHit; // 是否按下
 }PX_Object_Hammer;
 
-PX_OBJECT_RENDER_FUNCTION(PX_Object_HammerRender)//锤子渲染
+PX_OBJECT_RENDER_FUNCTION(PX_Object_HammerRender) // 锤子渲染
 {
 	PX_Object_Hammer* phammer = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_HAMMER);
 	px_float x, y, width, height;
 	PX_OBJECT_INHERIT_CODE(pObject, x, y, width, height);
 	if (phammer->bHit)
 	{
-		PX_TextureRender(psurface, &phammer->ham02, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL);//按下
+		PX_TextureRender(psurface, &phammer->ham02, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL); // 按下
 	}
 	else
 	{
-		PX_TextureRender(psurface, &phammer->ham01, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL);//未按下
+		PX_TextureRender(psurface, &phammer->ham01, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL); // 未按下
 	}
 	
 }
@@ -2049,20 +2050,20 @@ PX_OBJECT_FREE_FUNCTION(PX_Object_HammerFree)
 
 PX_OBJECT_EVENT_FUNCTION(PX_Object_HammerOnMove)
 {
-	pObject->x=PX_Object_Event_GetCursorX(e);//锤子跟随鼠标移动
+	pObject->x=PX_Object_Event_GetCursorX(e); // 锤子跟随鼠标移动
 	pObject->y=PX_Object_Event_GetCursorY(e);
 }
 
 PX_OBJECT_EVENT_FUNCTION(PX_Object_HammerOnCursorDown)
 {
 	PX_Object_Hammer* phammer = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_HAMMER);
-	phammer->bHit = PX_TRUE;//按下
+	phammer->bHit = PX_TRUE; // 按下
 }
 
 PX_OBJECT_EVENT_FUNCTION(PX_Object_HammerOnCursorUp)
 {
 	PX_Object_Hammer* phammer = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_HAMMER);
-	phammer->bHit = PX_FALSE;//抬起
+	phammer->bHit = PX_FALSE; // 抬起
 }
 
 PX_Object* PX_Object_HammerCreate(px_memorypool* mp, PX_Object* parent)
@@ -2073,24 +2074,24 @@ PX_Object* PX_Object_HammerCreate(px_memorypool* mp, PX_Object* parent)
 	phammer->bHit = PX_FALSE;
 	if (!PX_LoadTextureFromFile(mp_static,&phammer->ham01, "assets/ham1.png")) return PX_NULL;
 	if (!PX_LoadTextureFromFile(mp_static,&phammer->ham02, "assets/ham2.png")) return PX_NULL;
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORMOVE, PX_Object_HammerOnMove, PX_NULL);//注册移动事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDRAG, PX_Object_HammerOnMove, PX_NULL);//注册拖拽事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnCursorDown, PX_NULL);//注册按下事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnMove, PX_NULL);//注册按下事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORUP, PX_Object_HammerOnCursorUp, PX_NULL);//注册抬起事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORMOVE, PX_Object_HammerOnMove, PX_NULL); // 注册移动事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDRAG, PX_Object_HammerOnMove, PX_NULL); // 注册拖拽事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnCursorDown, PX_NULL); // 注册按下事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnMove, PX_NULL); // 注册按下事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORUP, PX_Object_HammerOnCursorUp, PX_NULL); // 注册抬起事件
 
 	return pObject;
 }
 ```
 
-最后则是一个倒计时框, 它中间其实是一个 2dx 的动画对象(PainterEngine 直接支持 gif 动画, 其实 gif 也可以), 外围是一个环, 环形的弧度不断减少, 以实现一个 `倒计时` 的显示效果：
+最后则是一个倒计时框，它中间其实是一个 2dx 的动画对象（PainterEngine 直接支持 gif 动画，其实 gif 也可以），外围是一个环，环形的弧度不断减少，以实现一个 `倒计时` 的显示效果：
 
 ```c
 typedef struct
 {
-	PX_Animation animation;//动画
-	px_dword time;//倒计时时间
-	px_dword elapsed;//倒计时开始后已经过去的时间
+	PX_Animation animation; // 动画
+	px_dword time; // 倒计时时间
+	px_dword elapsed; // 倒计时开始后已经过去的时间
 }PX_Object_Clock;
 
 
@@ -2101,7 +2102,7 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_ClockUpdate)
 	if (clock->elapsed >= clock->time)
 	{
 		clock->elapsed = 0;
-		PX_ObjectPostEvent(game, PX_OBJECT_BUILD_EVENT(PX_OBJECT_EVENT_RESET));//重置狐狸状态,给game对象发送重置事件
+		PX_ObjectPostEvent(game, PX_OBJECT_BUILD_EVENT(PX_OBJECT_EVENT_RESET)); // 重置狐狸状态,给game对象发送重置事件
 		game->Visible = PX_FALSE;
 		game->Enabled = PX_FALSE;
 		startgame->Visible = PX_TRUE;
@@ -2114,11 +2115,11 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_ClockUpdate)
 PX_OBJECT_RENDER_FUNCTION(PX_Object_ClockRender)
 {
 	PX_Object_Clock* clock = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_CLOCK);
-	PX_AnimationUpdate(&clock->animation, elapsed);//更新动画
-	PX_AnimationRender(psurface, &clock->animation, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER, PX_NULL);//绘制动画
-	//draw ring
-	PX_GeoDrawCircle(psurface, (px_int)pObject->x, (px_int)pObject->y, 38, 8, PX_COLOR_BLACK);//绘制倒计时环边框
-	PX_GeoDrawRing(psurface, (px_int)pObject->x, (px_int)pObject->y, 36, 6, PX_COLOR(128,192,255,32), -90, -90 + (px_int)(360 * (1 - clock->elapsed * 1.0f / clock->time)));//绘制倒计时环
+	PX_AnimationUpdate(&clock->animation, elapsed); // 更新动画
+	PX_AnimationRender(psurface, &clock->animation, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER, PX_NULL); // 绘制动画
+	// draw ring
+	PX_GeoDrawCircle(psurface, (px_int)pObject->x, (px_int)pObject->y, 38, 8, PX_COLOR_BLACK); // 绘制倒计时环边框
+	PX_GeoDrawRing(psurface, (px_int)pObject->x, (px_int)pObject->y, 36, 6, PX_COLOR(128,192,255,32), -90, -90 + (px_int)(360 * (1 - clock->elapsed * 1.0f / clock->time))); // 绘制倒计时环
 }
 
 PX_OBJECT_FREE_FUNCTION(PX_Object_ClockFree)
@@ -2127,7 +2128,7 @@ PX_OBJECT_FREE_FUNCTION(PX_Object_ClockFree)
 	PX_AnimationFree(&clock->animation);
 }
 
-px_void PX_Object_ClockBegin(PX_Object* pClock, px_dword time)//开始倒计时
+px_void PX_Object_ClockBegin(PX_Object* pClock, px_dword time) // 开始倒计时
 {
 	PX_Object_Clock* clock = PX_ObjectGetDescByType(pClock, PX_OBJECT_TYPE_CLOCK);
 	clock->time = time;
@@ -2142,7 +2143,7 @@ PX_Object* PX_Object_ClockCreate(px_memorypool* mp, PX_Object* parent, px_float 
 	clock = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_CLOCK);
 	clock->time = 0;
 	clock->elapsed = 0;
-	if (!PX_AnimationCreate(&clock->animation, PX_ResourceLibraryGetAnimationLibrary(PainterEngine_GetResourceLibrary(), "song")))//从资源管理器中获取动画
+	if (!PX_AnimationCreate(&clock->animation, PX_ResourceLibraryGetAnimationLibrary(PainterEngine_GetResourceLibrary(), "song"))) // 从资源管理器中获取动画
 	{
 		PX_ObjectDelete(pObject);
 		return PX_NULL;
@@ -2153,12 +2154,12 @@ PX_Object* PX_Object_ClockCreate(px_memorypool* mp, PX_Object* parent, px_float 
 }
 ```
 
-### 放置对象, 完成游戏
+### 放置对象，完成游戏
 
-在 `main` 函数中, 我们将上述对象一一创建, 并放置在游戏场景中, 最终完成这个游戏：
+在 `main` 函数中，我们将上述对象一一创建，并放置在游戏场景中，最终完成这个游戏：
 
 ```c
-//创建地鼠
+// 创建地鼠
 game=PX_ObjectCreate(mp, root, 0, 0, 0, 0, 0, 0);
 PX_Object_FoxCreate(mp, game, 173, 326);
 PX_Object_FoxCreate(mp, game, 401, 326);
@@ -2169,14 +2170,14 @@ PX_Object_FoxCreate(mp, game, 636, 476);
 game->Visible=PX_FALSE;
 game->Enabled=PX_FALSE;
 
-//创建锤子
+// 创建锤子
 PX_Object_HammerCreate(mp, root);
 scorePanel = PX_Object_ScorePanelCreate(mp, root, 400, 60, &score_fm, 100);
-//创建倒计时框
+// 创建倒计时框
 gameclock=PX_Object_ClockCreate(mp,root,680,60);
 ```
 
-在这里, 我放上整个游戏的完整代码：
+在这里，我放上整个游戏的完整代码：
 
 ```c
 #include "PainterEngine.h"
@@ -2191,38 +2192,38 @@ PX_Object* game,*startgame,*gameclock;
 
 typedef enum
 {
-	PX_OBJECT_FOX_STATE_IDLE,//狐狸还在洞里
-	PX_OBJECT_FOX_STATE_RASING,//狐狸正在升起
-	PX_OBJECT_FOX_STATE_TAUNT,//狐狸在嘲讽
-	PX_OBJECT_FOX_STATE_ESCAPE,//狐狸逃跑
-	PX_OBJECT_FOX_STATE_BEAT,//狐狸被打
-	PX_OBJECT_FOX_STATE_HURT,//狐狸受伤后逃跑
+	PX_OBJECT_FOX_STATE_IDLE,   // 狐狸还在洞里
+	PX_OBJECT_FOX_STATE_RASING, // 狐狸正在升起
+	PX_OBJECT_FOX_STATE_TAUNT,  // 狐狸在嘲讽
+	PX_OBJECT_FOX_STATE_ESCAPE, // 狐狸逃跑
+	PX_OBJECT_FOX_STATE_BEAT,   // 狐狸被打
+	PX_OBJECT_FOX_STATE_HURT,   // 狐狸受伤后逃跑
 }PX_OBJECT_FOX_STATE;
 
 typedef struct
 {
-	PX_OBJECT_FOX_STATE state;//狐狸状态
-	px_dword elapsed;//状态持续时间
-	px_float texture_render_offset;//纹理渲染偏移
-	px_dword gen_rand_time;//生成随机时间
-	px_float rasing_down_speed;//升起速度
-	px_texture render_target;//渲染目标
-	px_texture* pcurrent_display_texture;//当前显示的纹理
-	px_texture* ptexture_mask;//遮罩
+	PX_OBJECT_FOX_STATE state;            // 狐狸状态
+	px_dword elapsed;                     // 状态持续时间
+	px_float texture_render_offset;       // 纹理渲染偏移
+	px_dword gen_rand_time;               // 生成随机时间
+	px_float rasing_down_speed;           // 升起速度
+	px_texture render_target;             // 渲染目标
+	px_texture* pcurrent_display_texture; // 当前显示的纹理
+	px_texture* ptexture_mask;            // 遮罩
 }PX_Object_Fox;
 
 typedef struct
 {
-	px_texture ham01;//锤子纹理1,没有按下
-	px_texture ham02;//锤子纹理2,按下
-	px_bool bHit;//是否按下
+	px_texture ham01; // 锤子纹理1,没有按下
+	px_texture ham02; // 锤子纹理2,按下
+	px_bool bHit; // 是否按下
 }PX_Object_Hammer;
 
 typedef struct
 {
-	PX_Animation animation;//动画
-	px_dword time;//倒计时时间
-	px_dword elapsed;//倒计时开始后已经过去的时间
+	PX_Animation animation; // 动画
+	px_dword time; // 倒计时时间
+	px_dword elapsed; // 倒计时开始后已经过去的时间
 }PX_Object_Clock;
 
 
@@ -2233,7 +2234,7 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_ClockUpdate)
 	if (clock->elapsed >= clock->time)
 	{
 		clock->elapsed = 0;
-		PX_ObjectPostEvent(game, PX_OBJECT_BUILD_EVENT(PX_OBJECT_EVENT_RESET));//重置狐狸状态,给game对象发送重置事件
+		PX_ObjectPostEvent(game, PX_OBJECT_BUILD_EVENT(PX_OBJECT_EVENT_RESET)); // 重置狐狸状态,给game对象发送重置事件
 		game->Visible = PX_FALSE;
 		game->Enabled = PX_FALSE;
 		startgame->Visible = PX_TRUE;
@@ -2246,11 +2247,11 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_ClockUpdate)
 PX_OBJECT_RENDER_FUNCTION(PX_Object_ClockRender)
 {
 	PX_Object_Clock* clock = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_CLOCK);
-	PX_AnimationUpdate(&clock->animation, elapsed);//更新动画
-	PX_AnimationRender(psurface, &clock->animation, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER, PX_NULL);//绘制动画
-	//draw ring
-	PX_GeoDrawCircle(psurface, (px_int)pObject->x, (px_int)pObject->y, 38, 8, PX_COLOR_BLACK);//绘制倒计时环边框
-	PX_GeoDrawRing(psurface, (px_int)pObject->x, (px_int)pObject->y, 36, 6, PX_COLOR(128,192,255,32), -90, -90 + (px_int)(360 * (1 - clock->elapsed * 1.0f / clock->time)));//绘制倒计时环
+	PX_AnimationUpdate(&clock->animation, elapsed); // 更新动画
+	PX_AnimationRender(psurface, &clock->animation, (px_int)pObject->x, (px_int)pObject->y, PX_ALIGN_CENTER, PX_NULL); // 绘制动画
+	// draw ring
+	PX_GeoDrawCircle(psurface, (px_int)pObject->x, (px_int)pObject->y, 38, 8, PX_COLOR_BLACK); // 绘制倒计时环边框
+	PX_GeoDrawRing(psurface, (px_int)pObject->x, (px_int)pObject->y, 36, 6, PX_COLOR(128,192,255,32), -90, -90 + (px_int)(360 * (1 - clock->elapsed * 1.0f / clock->time))); // 绘制倒计时环
 }
 
 PX_OBJECT_FREE_FUNCTION(PX_Object_ClockFree)
@@ -2259,7 +2260,7 @@ PX_OBJECT_FREE_FUNCTION(PX_Object_ClockFree)
 	PX_AnimationFree(&clock->animation);
 }
 
-px_void PX_Object_ClockBegin(PX_Object* pClock, px_dword time)//开始倒计时
+px_void PX_Object_ClockBegin(PX_Object* pClock, px_dword time) // 开始倒计时
 {
 	PX_Object_Clock* clock = PX_ObjectGetDescByType(pClock, PX_OBJECT_TYPE_CLOCK);
 	clock->time = time;
@@ -2274,7 +2275,7 @@ PX_Object* PX_Object_ClockCreate(px_memorypool* mp, PX_Object* parent, px_float 
 	clock = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_CLOCK);
 	clock->time = 0;
 	clock->elapsed = 0;
-	if (!PX_AnimationCreate(&clock->animation, PX_ResourceLibraryGetAnimationLibrary(PainterEngine_GetResourceLibrary(), "song")))//从资源管理器中获取动画
+	if (!PX_AnimationCreate(&clock->animation, PX_ResourceLibraryGetAnimationLibrary(PainterEngine_GetResourceLibrary(), "song"))) // 从资源管理器中获取动画
 	{
 		PX_ObjectDelete(pObject);
 		return PX_NULL;
@@ -2293,18 +2294,18 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_FoxOnUpdate)
 		{
 			if (pfox->gen_rand_time ==0)
 			{
-				pfox->gen_rand_time = PX_rand() % 3000 + 1000;//狐狸在洞里的时间,时间到了就升起来
+				pfox->gen_rand_time = PX_rand() % 3000 + 1000; // 狐狸在洞里的时间,时间到了就升起来
 			}
 			else
 			{
-				if (pfox->gen_rand_time <elapsed)//时间到了
+				if (pfox->gen_rand_time <elapsed) // 时间到了
 				{
-					//升起
+					// 升起
 					pfox->state = PX_OBJECT_FOX_STATE_RASING;
 					pfox->elapsed = 0;
 					pfox->gen_rand_time = 0;
 					pfox->texture_render_offset = pObject->Height;
-					//改变纹理
+					// 改变纹理
 					pfox->pcurrent_display_texture= PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_rasing");
 				}
 				else
@@ -2314,42 +2315,42 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_FoxOnUpdate)
 			}
 		}
 		break;
-		case PX_OBJECT_FOX_STATE_RASING://狐狸升起
+		case PX_OBJECT_FOX_STATE_RASING: // 狐狸升起
 		{
 			pfox->elapsed += elapsed;
-			//升起纹理偏移量
+			// 升起纹理偏移量
 			pfox->texture_render_offset -= pfox->rasing_down_speed * elapsed / 1000;
 			if (pfox->texture_render_offset <= 0)
 			{
 				pfox->texture_render_offset = 0;
-				pfox->state = PX_OBJECT_FOX_STATE_TAUNT;//升起后嘲讽
+				pfox->state = PX_OBJECT_FOX_STATE_TAUNT; // 升起后嘲讽
 				pfox->elapsed = 0;
 			}
 		}
 		break;
-		case PX_OBJECT_FOX_STATE_TAUNT://狐狸嘲讽
+		case PX_OBJECT_FOX_STATE_TAUNT: // 狐狸嘲讽
 		{
 			pfox->elapsed += elapsed;
-			if (pfox->elapsed>600&& pfox->elapsed <1500)//嘲讽时间
+			if (pfox->elapsed>600&& pfox->elapsed <1500) // 嘲讽时间
 			{
-				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_taunt");//嘲讽纹理
+				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_taunt"); // 嘲讽纹理
 			}
-			else if (pfox->elapsed>1500)//嘲讽结束
+			else if (pfox->elapsed>1500) // 嘲讽结束
 			{
 				pfox->texture_render_offset = 0;
-				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE;//逃跑
-				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_escape");//逃跑纹理
+				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE; // 逃跑
+				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_escape"); // 逃跑纹理
 				pfox->elapsed = 0;
 			}
 		}
 		break;
-		case PX_OBJECT_FOX_STATE_BEAT://狐狸被打
+		case PX_OBJECT_FOX_STATE_BEAT: // 狐狸被打
 		{
 			pfox->elapsed += elapsed;
 			if (pfox->elapsed>800)
 			{
-				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_hurt");//受伤纹理
-				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE;//逃跑
+				pfox->pcurrent_display_texture = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_hurt"); // 受伤纹理
+				pfox->state = PX_OBJECT_FOX_STATE_ESCAPE; // 逃跑
 			}
 		}
 		break;
@@ -2360,8 +2361,8 @@ PX_OBJECT_UPDATE_FUNCTION(PX_Object_FoxOnUpdate)
 			if (pfox->texture_render_offset >= pObject->Height)
 			{
 				pfox->texture_render_offset = pObject->Height;
-				pfox->state = PX_OBJECT_FOX_STATE_IDLE;//逃跑结束
-				pfox->elapsed = 0;//重置时间
+				pfox->state = PX_OBJECT_FOX_STATE_IDLE; // 逃跑结束
+				pfox->elapsed = 0; // 重置时间
 				pfox->pcurrent_display_texture = PX_NULL;
 			}
 		}
@@ -2376,12 +2377,12 @@ PX_OBJECT_RENDER_FUNCTION(PX_Object_FoxOnRender)
 	PX_Object_Fox* pfox = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_FOX);
 	px_float x,y,width,height;
 	PX_OBJECT_INHERIT_CODE(pObject,x,y,width,height);
-	PX_TextureClearAll(&pfox->render_target, PX_COLOR_NONE);//清空渲染目标
+	PX_TextureClearAll(&pfox->render_target, PX_COLOR_NONE); // 清空渲染目标
 	if (pfox->pcurrent_display_texture)
 	{
-		PX_TextureRender(&pfox->render_target, pfox->pcurrent_display_texture, (px_int)pfox->render_target.width/2, (px_int)pfox->texture_render_offset, PX_ALIGN_MIDTOP, PX_NULL);//渲染狐狸
+		PX_TextureRender(&pfox->render_target, pfox->pcurrent_display_texture, (px_int)pfox->render_target.width/2, (px_int)pfox->texture_render_offset, PX_ALIGN_MIDTOP, PX_NULL); // 渲染狐狸
 	}
-	PX_TextureRenderMask(psurface, pfox->ptexture_mask, &pfox->render_target, (px_int)x, (px_int)y, PX_ALIGN_MIDBOTTOM, PX_NULL);//以遮罩形式绘制纹理
+	PX_TextureRenderMask(psurface, pfox->ptexture_mask, &pfox->render_target, (px_int)x, (px_int)y, PX_ALIGN_MIDBOTTOM, PX_NULL); // 以遮罩形式绘制纹理
 }
 
 PX_OBJECT_FREE_FUNCTION(PX_Object_FoxFree)
@@ -2390,12 +2391,12 @@ PX_OBJECT_FREE_FUNCTION(PX_Object_FoxFree)
 	PX_TextureFree(&pfox->render_target);
 }
 
-PX_OBJECT_EVENT_FUNCTION(PX_Object_FoxOnClick)//狐狸被点击
+PX_OBJECT_EVENT_FUNCTION(PX_Object_FoxOnClick) // 狐狸被点击
 {
 	PX_Object_Fox* pfox = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_FOX);
-	if (pfox->state == PX_OBJECT_FOX_STATE_TAUNT|| pfox->state == PX_OBJECT_FOX_STATE_RASING)//狐狸嘲讽或者升起时点击有效
+	if (pfox->state == PX_OBJECT_FOX_STATE_TAUNT|| pfox->state == PX_OBJECT_FOX_STATE_RASING) // 狐狸嘲讽或者升起时点击有效
 	{
-		if (PX_ObjectIsCursorInRegionAlign(pObject, e, PX_ALIGN_MIDBOTTOM))//点击有效区域
+		if (PX_ObjectIsCursorInRegionAlign(pObject, e, PX_ALIGN_MIDBOTTOM)) // 点击有效区域
 		{
 			px_int x= (px_int)PX_Object_Event_GetCursorX(e);
 			px_int y= (px_int)PX_Object_Event_GetCursorY(e);
@@ -2427,34 +2428,34 @@ PX_OBJECT_EVENT_FUNCTION(PX_Object_FoxOnReset)
 PX_Object *PX_Object_FoxCreate(px_memorypool *mp,PX_Object *parent,px_float x,px_float y)
 {
 	PX_Object_Fox* pfox;
-	px_texture *ptexture=PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(),"fox_rasing");//从资源管理器中获取纹理
+	px_texture *ptexture=PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(),"fox_rasing"); // 从资源管理器中获取纹理
 	PX_Object* pObject = PX_ObjectCreateEx(mp, parent, x, y, 0, ptexture->width*1.f, ptexture->height*1.f, 0, PX_OBJECT_TYPE_FOX, PX_Object_FoxOnUpdate, PX_Object_FoxOnRender, PX_Object_FoxFree, 0, sizeof(PX_Object_Fox));
 	pfox=PX_ObjectGetDescByType(pObject,PX_OBJECT_TYPE_FOX);
-	pfox->state= PX_OBJECT_FOX_STATE_IDLE;//狐狸状态
-	pfox->rasing_down_speed = 512;//升起速度
-	pfox->ptexture_mask = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_mask");//遮罩
+	pfox->state= PX_OBJECT_FOX_STATE_IDLE; // 狐狸状态
+	pfox->rasing_down_speed = 512; // 升起速度
+	pfox->ptexture_mask = PX_ResourceLibraryGetTexture(PainterEngine_GetResourceLibrary(), "fox_mask"); // 遮罩
 	if(!PX_TextureCreate(mp,&pfox->render_target,ptexture->width,ptexture->height))
 	{
 		PX_ObjectDelete(pObject);
 		return 0;
 	}
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDOWN,PX_Object_FoxOnClick,0);//注册点击事件
-	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_RESET,PX_Object_FoxOnReset,0);//注册重置事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_CURSORDOWN,PX_Object_FoxOnClick,0); // 注册点击事件
+	PX_ObjectRegisterEvent(pObject,PX_OBJECT_EVENT_RESET,PX_Object_FoxOnReset,0); // 注册重置事件
 	return pObject;
 }
 
-PX_OBJECT_RENDER_FUNCTION(PX_Object_HammerRender)//锤子渲染
+PX_OBJECT_RENDER_FUNCTION(PX_Object_HammerRender) // 锤子渲染
 {
 	PX_Object_Hammer* phammer = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_HAMMER);
 	px_float x, y, width, height;
 	PX_OBJECT_INHERIT_CODE(pObject, x, y, width, height);
 	if (phammer->bHit)
 	{
-		PX_TextureRender(psurface, &phammer->ham02, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL);//按下
+		PX_TextureRender(psurface, &phammer->ham02, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL); // 按下
 	}
 	else
 	{
-		PX_TextureRender(psurface, &phammer->ham01, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL);//未按下
+		PX_TextureRender(psurface, &phammer->ham01, (px_int)x, (px_int)y, PX_ALIGN_CENTER, PX_NULL); // 未按下
 	}
 	
 }
@@ -2468,20 +2469,20 @@ PX_OBJECT_FREE_FUNCTION(PX_Object_HammerFree)
 
 PX_OBJECT_EVENT_FUNCTION(PX_Object_HammerOnMove)
 {
-	pObject->x=PX_Object_Event_GetCursorX(e);//锤子跟随鼠标移动
+	pObject->x=PX_Object_Event_GetCursorX(e); // 锤子跟随鼠标移动
 	pObject->y=PX_Object_Event_GetCursorY(e);
 }
 
 PX_OBJECT_EVENT_FUNCTION(PX_Object_HammerOnCursorDown)
 {
 	PX_Object_Hammer* phammer = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_HAMMER);
-	phammer->bHit = PX_TRUE;//按下
+	phammer->bHit = PX_TRUE; // 按下
 }
 
 PX_OBJECT_EVENT_FUNCTION(PX_Object_HammerOnCursorUp)
 {
 	PX_Object_Hammer* phammer = PX_ObjectGetDescByType(pObject, PX_OBJECT_TYPE_HAMMER);
-	phammer->bHit = PX_FALSE;//抬起
+	phammer->bHit = PX_FALSE; // 抬起
 }
 
 PX_Object* PX_Object_HammerCreate(px_memorypool* mp, PX_Object* parent)
@@ -2492,11 +2493,11 @@ PX_Object* PX_Object_HammerCreate(px_memorypool* mp, PX_Object* parent)
 	phammer->bHit = PX_FALSE;
 	if (!PX_LoadTextureFromFile(mp_static,&phammer->ham01, "assets/ham1.png")) return PX_NULL;
 	if (!PX_LoadTextureFromFile(mp_static,&phammer->ham02, "assets/ham2.png")) return PX_NULL;
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORMOVE, PX_Object_HammerOnMove, PX_NULL);//注册移动事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDRAG, PX_Object_HammerOnMove, PX_NULL);//注册拖拽事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnCursorDown, PX_NULL);//注册按下事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnMove, PX_NULL);//注册按下事件
-	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORUP, PX_Object_HammerOnCursorUp, PX_NULL);//注册抬起事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORMOVE, PX_Object_HammerOnMove, PX_NULL); // 注册移动事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDRAG, PX_Object_HammerOnMove, PX_NULL); // 注册拖拽事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnCursorDown, PX_NULL); // 注册按下事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORDOWN, PX_Object_HammerOnMove, PX_NULL); // 注册按下事件
+	PX_ObjectRegisterEvent(pObject, PX_OBJECT_EVENT_CURSORUP, PX_Object_HammerOnCursorUp, PX_NULL); // 注册抬起事件
 
 	return pObject;
 }
@@ -2507,7 +2508,7 @@ PX_OBJECT_EVENT_FUNCTION(PX_Object_StartGameOnClick)
 	startgame->Visible = PX_FALSE;
 	game->Enabled = PX_TRUE;
 	PX_Object_ScorePanelSetScore(scorePanel, 0);
-	PX_Object_ClockBegin(gameclock, 30000);//开始游戏,游戏时间30秒
+	PX_Object_ClockBegin(gameclock, 30000); // 开始游戏,游戏时间30秒
 }
 
 
@@ -2569,9 +2570,9 @@ px_int main()
 }
 ```
 
-你可以在 documents/demo/game 中找到这个游戏的完整资源, 并用 PainterEngine 直接编译。
+你可以在 documents/demo/game 中找到这个游戏的完整资源，并用 PainterEngine 直接编译。
 
 ![](assets/img/18.5.gif)
 
-在线试玩: [PainterEngine 在线应用 APP--打地鼠](https://www.painterengine.com/main/app/documentgame/)
+在线试玩：[PainterEngine 在线应用 APP——打地鼠](https://www.painterengine.com/main/app/documentgame/)
 


### PR DESCRIPTION
- Use Chinese punctuation for Chinese text and English punctuation for English text.
- Add spaces around the comment symbols in markdown code blocks.
- Adjust indent and alignment of some code and comments in code blocks.
- Included the missing modifications from the previous PR.

- 修改标点，中文用中文标点，英文用英文标点；
- 修改代码块中的注释，注释符号两边加空格；
- 修改代码块中的缩进与对齐；
- 补上上次PR的提交中漏掉的应当修改的地方。

没看住 VSCode，提交时没保存我最新的 commit message，本来一次提交就完事了的（半恼）
提交完这个就接着整翻译了