### PR TITLE
fix PX_Initialize bug

### DIFF
--- a/kernel/PX_Object_Firework.c
+++ b/kernel/PX_Object_Firework.c
@@ -166,6 +166,8 @@ PX_OBJECT_RENDER_FUNCTION(PX_Object_Firework01Render)
 
 PX_Object* PX_Object_Firework01Create(px_memorypool* mp, PX_Object* Parent, px_float x, px_float y)
 {
+	if (!mp) return PX_NULL;
+	
 	px_int i;
 	PX_Object_Firework01 desc;
 	PX_memset(&desc, 0, sizeof(desc));

--- a/runtime/PainterEngine_Application.c
+++ b/runtime/PainterEngine_Application.c
@@ -273,11 +273,13 @@ px_bool PainterEngine_Initialize(px_int _screen_width,px_int _screen_height)
 	App.object_root = PX_ObjectCreateRoot(&runtime->mp_static);
 	if (!App.object_root)
 	{
+		mp = NULL;
 		return PX_FALSE;
 	}
 	App.object_printer=PX_Object_PrinterCreate(&runtime->mp, App.object_root, 0, 0, _screen_width, _screen_height, App.pfontmodule);
 	if (!App.object_printer)
 	{
+		mp = NULL;
 		return PX_FALSE;
 	}
 	PX_Object_PanelAttachObject(App.object_printer, PX_ObjectGetFreeDescIndex(App.object_printer));
@@ -374,6 +376,12 @@ px_bool PX_ApplicationInitialize(PX_Application *pApp,px_int screen_width,px_int
 	PainterEngine_SetBackgroundColor(PX_COLOR_BACKGROUNDCOLOR);
 
 	px_main();
+
+	if (mp == PX_NULL){
+		printf("PainterEngine_Initialize:Create MemoryPool failed! \n");
+		printf("The window size must be set larger than 24 * 24! \n");
+		return PX_FALSE;
+	}
 	
 	if (pApp->runtime.window_height&&pApp->runtime.window_width&& pApp->runtime.surface_height&& pApp->runtime.surface_width)
 	{


### PR DESCRIPTION
Fix #119 
## Fix SEGV crash when screen size is too small

When screen dimensions are less than 25x25, PX_Object_ScrollAreaCreate() returns PX_NULL, but PainterEngine_Initialize() did not properly handle this case and continued execution with an uninitialized memory pool pointer (mp). This led to a SEGV crash when the null pointer was later dereferenced.
### by:
1. Adding null pointer check for mp in PX_Object_FireworkKICreate()
2. Initializing mp to NULL in PainterEngine_Initialize()
3. Adding proper error handling when mp initialization fails:
   - Add error messages for failed memory pool initialization
   - Add message indicating minimum window size requirement (24x24)
   - Return PX_FALSE to prevent further execution with invalid mp
