### PR TITLE
docs: 更正文档中对于 VSCode 终端字符编码的枚举量错误 (GBK -> UTF-8)

### DIFF
--- a/documents/PainterEngine the book.en.md
+++ b/documents/PainterEngine the book.en.md
@@ -207,7 +207,7 @@ int main()
 
 ![](assets/img/3.3.png)
 
-The first parameter of the `PainterEngine_LoadFontModule` function is the path to the TTF font file, with the relative path being relative to the location of the executable file. The second parameter specifies the character set. By default, Visual Studio uses the GBK character set. If you are using Visual Studio Code, which defaults to UTF-8 encoding, the second parameter should be set to `PX_FONTMODULE_CODEPAGE_GBK`. The last parameter specifies the font size.
+The first parameter of the `PainterEngine_LoadFontModule` function is the path to the TTF font file, with the relative path being relative to the location of the executable file. The second parameter specifies the character set. By default, Visual Studio uses the GBK character set. If you are using Visual Studio Code, which defaults to UTF-8 encoding, the second parameter should be set to `PX_FONTMODULE_CODEPAGE_UTF8`. The last parameter specifies the font size.
 
 ## 4. Drawing Geometric Shapes with PainterEngine
 

--- a/documents/PainterEngine the book.md
+++ b/documents/PainterEngine the book.md
@@ -201,7 +201,7 @@ int main()
 
 ![](assets/img/3.3.png)
 
-`PainterEngine_LoadFontModule` 的函数的第一个参数是 TTF 字体文件的路径, 相对路径是以 exe 文件所在路径相对的。第二个参数是字符集，在默认情况下, Visual Studio 代码使用的是 GBK 字符集。如果你使用 Visual Studio Code, 那么默认是 UTF8 编码, 第二个参数应该换成 `PX_FONTMODULE_CODEPAGE_GBK`。最后一个参数是字体的大小。
+`PainterEngine_LoadFontModule` 的函数的第一个参数是 TTF 字体文件的路径, 相对路径是以 exe 文件所在路径相对的。第二个参数是字符集，在默认情况下, Visual Studio 代码使用的是 GBK 字符集。如果你使用 Visual Studio Code, 那么默认是 UTF8 编码, 第二个参数应该换成 `PX_FONTMODULE_CODEPAGE_UTF8`。最后一个参数是字体的大小。
 
 ## 4. 使用 PainterEngine 绘制几何图形
 


### PR DESCRIPTION
如题，第二个参数应该换成的宏应为 `PX_FONTMODULE_CODEPAGE_UTF8` 而不是 `PX_FONTMODULE_CODEPAGE_GBK`

下图是项目原来文档的截图
![image](https://github.com/user-attachments/assets/6e5283ef-a5ea-4bcb-b98e-7f629b73cb21)
