### PR TITLE
Update UEFI platform to work with edk2 mainline

### DIFF
--- a/platform/uefi/ChkStk.c
+++ b/platform/uefi/ChkStk.c
@@ -1,0 +1,9 @@
+
+/**
+  Hack function for passing MSFT build.
+**/
+VOID
+__chkstk (
+  )
+{
+}

--- a/platform/uefi/MemIntrinsicMs.c
+++ b/platform/uefi/MemIntrinsicMs.c
@@ -1,0 +1,121 @@
+
+typedef UINTN size_t;
+
+int
+memcmp (
+  void *,
+  void *,
+  size_t
+  );
+
+int
+memcmp (
+  const void  *s1,
+  const void  *s2,
+  size_t      n
+  )
+{
+  unsigned char const  *t1;
+  unsigned char const  *t2;
+
+  t1 = s1;
+  t2 = s2;
+
+  while (n-- != 0) {
+    if (*t1 != *t2) {
+      return (int)*t1 - (int)*t2;
+    }
+
+    t1++;
+    t2++;
+  }
+
+  return 0;
+}
+
+void *
+memcpy (
+  void *,
+  const void *,
+  size_t
+  );
+
+void *
+memcpy (
+  void        *dest,
+  const void  *src,
+  size_t      n
+  )
+{
+  unsigned char        *d;
+  unsigned char const  *s;
+
+  d = dest;
+  s = src;
+
+  while (n-- != 0) {
+    *d++ = *s++;
+  }
+
+  return dest;
+}
+
+void *
+memmove (
+  void *,
+  const void *,
+  size_t
+  );
+
+void *
+memmove (
+  void        *dest,
+  const void  *src,
+  size_t      n
+  )
+{
+  unsigned char        *d;
+  unsigned char const  *s;
+
+  d = dest;
+  s = src;
+
+  if (d < s) {
+    while (n-- != 0) {
+      *d++ = *s++;
+    }
+  } else {
+    d += n;
+    s += n;
+    while (n-- != 0) {
+      *--d = *--s;
+    }
+  }
+
+  return dest;
+}
+
+void *
+memset (
+  void *,
+  int,
+  size_t
+  );
+
+void *
+memset (
+  void    *s,
+  int     c,
+  size_t  n
+  )
+{
+  unsigned char  *d;
+
+  d = s;
+
+  while (n-- != 0) {
+    *d++ = (unsigned char)c;
+  }
+
+  return s;
+}

--- a/platform/uefi/PainterEngine.dsc
+++ b/platform/uefi/PainterEngine.dsc
@@ -133,7 +133,6 @@
 
   PainterEngine/platform/uefi/PainterEngineTemplate.inf {
     <LibraryClasses>
-      NULL|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
       !if $(REAL_TIMER_LIB) == TRUE
       # TimerLib|[PATH-TO-SPECIFIC-TIMER-LIB]/xxxTimerLib.inf
       !endif

--- a/platform/uefi/PainterEngineTemplate.inf
+++ b/platform/uefi/PainterEngineTemplate.inf
@@ -190,6 +190,10 @@
   ../../runtime/PainterEngine_Application.c
   ../../runtime/PainterEngine_Runtime.c
 
+[Sources.X64]
+  # MemIntrinsicWrapper
+  MemIntrinsicMs.c | MSFT
+
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
@@ -219,7 +223,6 @@
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS = /wd4201 /wd4244 /wd4456 /wd4189 /wd4310 /wd4389 /wd4005 /wd4245 /wd4457 /wd4702 /wd4706 /wd4204 /wd4054 /wd4055
 
-  # __chkstk need this
-  # MSFT:*_*_*_CC_FLAGS = /GL-
+  MSFT:*_*_*_CC_FLAGS = /GL-
 
   GCC:*_*_*_CC_FLAGS = -Wno-error

--- a/platform/uefi/PainterEngineTemplate.inf
+++ b/platform/uefi/PainterEngineTemplate.inf
@@ -225,4 +225,6 @@
 
   MSFT:*_*_*_CC_FLAGS = /GL-
 
+  MSFT:RELEASE_*_*_DLINK_FLAGS = /SECTION:.bss,ERW
+
   GCC:*_*_*_CC_FLAGS = -Wno-error

--- a/platform/uefi/PainterEngineTemplate.inf
+++ b/platform/uefi/PainterEngineTemplate.inf
@@ -194,6 +194,8 @@
   # MemIntrinsicWrapper
   MemIntrinsicMs.c | MSFT
 
+  ChkStk.c | MSFT
+
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec

--- a/platform/uefi/px_file.c
+++ b/platform/uefi/px_file.c
@@ -104,6 +104,9 @@ PX_IO_Data PX_LoadFileToIOData(const char path[])
         io.size = FileBufferSize;
       }
     }
+    if (Char16Path != NULL) {
+      FreePool (Char16Path);
+    }
   }
 
   return io;

--- a/platform/uefi/px_main.c
+++ b/platform/uefi/px_main.c
@@ -329,7 +329,7 @@ PainterEngineUefiMain (
   px_dword timelasttime = 0;
 #endif
   EFI_STATUS  Status;
-  EFI_EVENT   MouseEvent;
+  EFI_EVENT   EfiInputEvent;
 
   Status = gBS->LocateProtocol (&gEfiGraphicsOutputProtocolGuid, NULL, (VOID **) &mEfiGop);
   if (!EFI_ERROR(Status)) {
@@ -352,10 +352,10 @@ PainterEngineUefiMain (
                   TPL_NOTIFY,
                   (EFI_EVENT_NOTIFY) CheckEfiInputEvent,
                   (VOID*)NULL,
-                  &MouseEvent
+                  &EfiInputEvent
                   );
 
-  Status = gBS->SetTimer (MouseEvent, TimerPeriodic, 10 * 10000); // 10ms
+  Status = gBS->SetTimer (EfiInputEvent, TimerPeriodic, 10 * 10000); // 10ms
 
 #ifdef REAL_TIMER_LIB
   timelasttime=PX_TimeGetTime();


### PR DESCRIPTION
Major changes:

1. Remove the use of `CompilerIntrinsicsLib`, it's support of X64 need RFC under tianocore/edk2
2. Add ChkStk.c to provide `__chkstk `for MSFT X64
3. Add MSFT:RELEASE_*_*_DLINK_FLAGS = /SECTION:.bss,ERW BuildOptions to prevent `App.cache[]` in Microsoft Release version from increasing the size of .efi image