### PR TITLE
在PX_GeoRasterizeTriangle函数中使用zbuffer ；将PX_GeoRasterizeTriangle函数中对px_int的位操作修改为比较；调整PX_3D_Present中部分代码的位置

### DIFF
--- a/core/PX_3D.c
+++ b/core/PX_3D.c
@@ -939,21 +939,28 @@ px_void PX_3D_Present(px_surface *psurface, PX_3D_RenderList *list,PX_3D_Camera 
 
 				if (1)
 				{
-					px_int x0, y0, x1, y1, x2, y2;
-					px_float alpha;
 					px_float cosv = PX_Point4DDot(PX_Point4DUnit(pface->transform_vertex[0].normal), PX_POINT4D(0, 0, 1));
-					x0 = (px_int)pface->transform_vertex[0].position.x;
-					y0 = (px_int)pface->transform_vertex[0].position.y;
-					x1 = (px_int)pface->transform_vertex[1].position.x;
-					y1 = (px_int)pface->transform_vertex[1].position.y;
-					x2 = (px_int)pface->transform_vertex[2].position.x;
-					y2 = (px_int)pface->transform_vertex[2].position.y;
-					
-					cosv = -cosv;
-					if (cosv > 0)
+
+					if (cosv < 0)
 					{
+						px_int x0, y0, x1, y1, x2, y2;
+						px_int z0, z1, z2;
+						px_float alpha;
+
+						x0 = (px_int)pface->transform_vertex[0].position.x;
+						y0 = (px_int)pface->transform_vertex[0].position.y;
+						x1 = (px_int)pface->transform_vertex[1].position.x;
+						y1 = (px_int)pface->transform_vertex[1].position.y;
+						x2 = (px_int)pface->transform_vertex[2].position.x;
+						y2 = (px_int)pface->transform_vertex[2].position.y;
+
+						z0 = (px_int)pface->transform_vertex[0].position.z;
+						z1 = (px_int)pface->transform_vertex[1].position.z;
+						z2 = (px_int)pface->transform_vertex[2].position.z;
+
+						cosv = -cosv;
 						alpha = (1 - cosv) * 128;
-						PX_GeoRasterizeTriangle(psurface,x0,y0,x1,y1,x2,y2,  PX_COLOR(255, (px_uchar)(128 + alpha), (px_uchar)(128 + alpha), (px_uchar)(128 + alpha)));
+						PX_GeoRasterizeTriangle(psurface,x0,y0,x1,y1,x2,y2,  PX_COLOR(255, (px_uchar)(128 + alpha), (px_uchar)(128 + alpha), (px_uchar)(128 + alpha)), (px_int)camera->viewport_width, (px_int)camera->viewport_height, camera->zbuffer, (px_int)camera->viewport_width, z0, z1, z2);
 					}
 
 				}

--- a/core/PX_BaseGeo.h
+++ b/core/PX_BaseGeo.h
@@ -32,6 +32,6 @@ px_void PX_GeoDrawBresenhamLine(px_surface* psurface, px_int x0, px_int y0, px_i
 px_void PX_GeoDrawTriangle(px_surface *psurface,px_point2D p0,px_point2D p1,px_point2D p2,px_color color);
 px_void PX_GeoDrawArrow(px_surface *psurface,px_point2D p0,px_point2D p1,px_float size,px_color color);
 px_void PX_GeoBSpline3(px_point2D controlPoints[4], px_point2D _samples[], px_int samplescount);
-px_void PX_GeoRasterizeTriangle(px_surface* psurface, px_int x1, px_int y1, px_int x2, px_int y2, px_int x3, px_int y3, px_color color);
+px_void PX_GeoRasterizeTriangle(px_surface* psurface, px_int x1, px_int y1, px_int x2, px_int y2, px_int x3, px_int y3, px_color color, px_int view_width, px_int view_height, px_float zbuffer[], px_int zw, px_float z0, px_float z1, px_float z2);
 
 #endif


### PR DESCRIPTION
处理 PX_GeoRasterizeTriangle 函数中未使用 zbuffer 导致3D模型显示异常的问题；
处理 PX_GeoRasterizeTriangle 函数中对 px_int 的位操作中假定 px_int 为 32bit 的问题；
将 PX_3D_Present 函数中对只在分支中才会使用到的变量的赋值操作移动分支内部以求执行效率。